### PR TITLE
Commit for #1 - X3D Archetype

### DIFF
--- a/x3do/README.md
+++ b/x3do/README.md
@@ -1,0 +1,56 @@
+# X3D Archetype
+
+This archetype is for the [X3D](https://www.web3d.org/working-groups/x3d-semantic-web) vocabulary. No constraints are defined for this archetype at this time.
+
+A good example set of instance data can be found in the X3D Examples Archive, for example [CAD Part No Transformation](https://www.web3d.org/x3d/content/examples/Basic/CAD/CADPartChildNoTransformationIndex.html).
+
+# Example queries
+
+From the X3D site, example queries of the ontology in the named graph:
+
+ * `<http://www.web3d.org/specifications/X3dOntology4.0#>`
+
+Example:
+
+```
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+PREFIX x3d:  <http://www.web3d.org/specifications/x3d-4.0.xsd#>
+PREFIX x3do: <http://www.web3d.org/specifications/X3dOntology4.0#>
+
+# X3dOntologyQuery_02.rq
+#   Metaquery to list nodes and statements (concrete owl:Class) that have
+#   inherited node types and object types, as defined in X3D Ontology.
+
+###############################################
+
+SELECT distinct (?classes AS ?NodesAndStatements) ?nodeTypes # (str(?lab) AS ?label)
+FROM <http://www.web3d.org/specifications/X3dOntology4.0#>
+WHERE {
+	?classes
+        rdf:type         owl:Class ;
+        rdfs:subClassOf* ?nodeTypes ;
+	    rdfs:label       ?lab .
+    FILTER ( !CONTAINS(str(?classes),"X3D") || STRENDS(str(?classes),"X3D") ) # no X3D node types
+}
+ORDER by ASC(?classes) # alphabetize
+
+###############################################
+
+```
+
+
+Example with reasoning using the CAD Part example:
+
+```
+select * 
+where {
+    ?s a x3do:X3DNode .
+} limit 15
+
+```
+
+
+

--- a/x3do/namespaces.ttl
+++ b/x3do/namespaces.ttl
@@ -1,0 +1,3 @@
+prefix x3do:   <http://www.web3d.org/specifications/X3dOntology4.0#> 
+prefix x3d:    <http://www.web3d.org/specifications/x3d-4.0.xsd#>
+prefix dc:     <http://purl.org/dc/terms/> 

--- a/x3do/schema/x3do.ttl
+++ b/x3do/schema/x3do.ttl
@@ -1,0 +1,8408 @@
+@prefix :       <http://www.web3d.org/specifications/X3dOntology4.0#> .
+@prefix x3do:   <http://www.web3d.org/specifications/X3dOntology4.0#> .
+@prefix dc:     <http://purl.org/dc/terms/> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xs:     <http://www.w3.org/2001/XMLSchema#> .
+
+###############################################
+
+# X3D Ontology
+
+<http://www.web3d.org/specifications/X3dOntology4.0> a owl:Ontology ;
+  dc:title       "X3D Ontology"@en ;
+  dc:description "The X3D Ontology for Semantic Web provides terms of reference for semantic query of X3D models." ;
+  dc:reference   "https://www.web3d.org/x3d/content/semantics/semantics.html" .
+  # TODO include further provenance information
+            
+# Maintained at
+#	http://www.web3d.org/specifications/X3dOntology4.0.ttl
+#	http://www.web3d.org/x3d/content/semantics/ontologies/X3dOntology4.0.ttl
+#
+# Support
+#   https://www.web3d.org/x3d/content/semantics/semantics.html
+#
+# Version control
+#	https://sourceforge.net/p/x3d/code/HEAD/tree/www.web3d.org/semantics/
+#	https://sourceforge.net/p/x3d/code/HEAD/tree/www.web3d.org/semantics/ontologies/X3dOntology4.0.ttl
+#	https://sourceforge.net/p/x3d/code/HEAD/tree/www.web3d.org/semantics/ontologies/X3dOntology4.0.ttl?format=raw
+
+###############################################
+
+# OWL validation available at
+#   http://mowl-power.cs.man.ac.uk:8080/validator (Profile OWL 2, Report syntax: Manchester Owl Syntax)
+#   http://visualdataweb.de/validator
+#
+# Protege Ontology Editor
+#   https://protege.stanford.edu
+
+###############################################
+            
+# Design Plan
+
+# - Show current work and plans at Web3D 2019 for discussion and comment
+# - Continue testing X3D Ontology with SPARQL queries
+# - Show interesting inferencing within/among X3D models
+# - Consider adding semantic metadata to models in X3D Examples Archive
+# -    https://www.web3d.org/x3d/content/examples/X3dResources.html#Examples
+# - Add relations and rules for mapping 3D-specific and domain-specific ontologies
+# - Build knowledge bases from current X3D scenes (initially)
+# - Continue following patterns in Leslie Sikos' t3dmo.ttl to provide relations
+# -    to other 3D file formats (perhaps OBJ first, then Max and others)
+# - Write parsers for other 3D formats using Data Format Description Language (DFDL)
+# -    https://daffodil.apache.org
+# - Demonstrate general 3D query and inferencing capabilities for multiple formats
+# - Write SPARQL "smoke test" assertions to check these are working correctly.
+            
+###############################################
+
+# Special Properties
+
+:hasChild a owl:ObjectProperty ;
+  rdfs:subPropertyOf :hasDescendant ;
+  dc:description "X3D element (node or statement) has a child element" .
+
+:hasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChild;
+  rdfs:subPropertyOf :hasAncestor ;
+  dc:description "X3D element (node or statement) has a parent element" .
+
+:hasDescendant a owl:ObjectProperty ;
+  owl:inverseOf :hasAncestor;
+  dc:description "X3D element (node or statement) has descendant element" .
+            
+:hasAncestor a owl:ObjectProperty , owl:TransitiveProperty ;
+  dc:description "X3D element (node or statement) has ancestor element" .
+
+###############################################
+            
+# FieldTypes
+
+:X3DField a rdfs:Datatype ;
+  rdfs:label "X3DField is the abstract field type from which all single-valued field types are derived." ;
+  dc:reference   "https://www.web3d.org/x3d/tooltips/X3dTooltips.html#FieldTypesTable" ;
+  dc:reference   "https://www.web3d.org/documents/specifications/19775-1/V3.3/Part01/fieldsDef.html#X3DField" .
+
+:SFBool rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFBool is a logical type with possible values (true|false) to match the XML boolean type" .
+:MFBool rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFBool is an array of Boolean values" .
+:SFColor rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "The SFColor field specifies one RGB (red-green-blue) color triple" .
+:MFColor rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFColor specifies zero or more SFColor RGB triples" .
+:SFColorRGBA rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "The SFColorRGBA field specifies one RGBA (red-green-blue-alpha) color 4-tuple" .
+:MFColorRGBA rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFColorRGBA specifies zero or more SFColorRGBA 4-tuples" .
+:SFDouble rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFDouble is a double-precision floating-point type" .
+:MFDouble rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFDouble is an array of Double values, meaning a double-precision floating-point array type" .
+:SFFloat rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFFloat is a single-precision floating-point type" .
+:MFFloat rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFFloat is an array of SFFloat values, meaning a single-precision floating-point array type" .
+:SFImage rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "The SFImage field specifies a single uncompressed 2-dimensional pixel image" .
+:MFImage rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFImage is an array of SFImage values" .
+:SFInt32 rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "An SFInt32 field specifies one 32-bit signed integer" .
+:MFInt32 rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "An MFInt32 field defines an array of 32-bit signed integers" .
+:SFMatrix3d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFMatrix3d specifies a 3x3 matrix of double-precision floating point numbers, organized in row-major fashion" .
+:MFMatrix3d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFMatrix3d specifies zero or more 3x3 matrices of double-precision floating point numbers, organized in row-major fashion" .
+:SFMatrix3f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFMatrix3f specifies a 3x3 matrix of single-precision floating point numbers, organized in row-major fashion" .
+:MFMatrix3f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFMatrix3f specifies zero or more 3x3 matrices of single-precision floating point numbers, organized in row-major fashion" .
+:SFMatrix4d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFMatrix4d specifies a 4x4 matrix of double-precision floating point numbers, organized in row-major fashion" .
+:MFMatrix4d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFMatrix4d specifies zero or more 4x4 matrices of double-precision floating point numbers, organized in row-major fashion" .
+:SFMatrix4f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFMatrix4f specifies a 4x4 matrix of single-precision floating point numbers, organized in row-major fashion" .
+:MFMatrix4f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFMatrix4f specifies zero or more 4x4 matrices of single-precision floating point numbers, organized in row-major fashion" .
+# SFNode TODO questionable, remove or refactor? .
+# MFNode TODO questionable, remove or refactor? .
+:SFRotation rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFRotation is an axis-angle 4-tuple, indicating X-Y-Z direction axis plus angle orientation about that axis" .
+:MFRotation rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFRotation is an array of SFRotation values" .
+:SFString rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFString defines a single string encoded with the UTF-8 universal character set" .
+:MFString rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFString is an array of SFString values, each quoted and separated by whitespace" .
+:SFTime rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "The SFTime field specifies a single time value" .
+:MFTime rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFTime is an array of SFTime values" .
+:SFVec2d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec2d is a 2-tuple pair of SFDouble values" .
+:MFVec2d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec2d is an array of SFVec2d values" .
+:SFVec2f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec2f is a 2-tuple pair of SFFloat values" .
+:MFVec2f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec2f is an array of SFVec2f values" .
+:SFVec3d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec3d is a 3-tuple triplet of SFDouble values" .
+:MFVec3d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec3d is an array of SFVec3d values" .
+:SFVec3f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec3f is a 3-tuple triplet of SFFloat values" .
+:MFVec3f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec3f is an array of SFVec3f values" .
+:SFVec4d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec4d is a 4-tuple set of double-precision floating-point values, specifying a 3D homogeneous vector" .
+:MFVec4d rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec4d is zero or more SFVec4d values" .
+:SFVec4f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "SFVec4f is a 4-tuple set of single-precision floating-point values, specifying a 3D homogeneous vector" .
+:MFVec4f rdf:type rdfs:Datatype ;
+  rdfs:subClassOf :X3DField ;
+  dc:description "MFVec4f is zero or more SFVec4f values" .
+
+###############################################
+
+# SimpleTypeEnumerations
+
+:accessTypeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "accessTypeChoices" ;
+  dc:description "accessTypeChoices are strictly allowed enumeration values for accessType" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'initializeOnly' 'inputOnly' 'outputOnly' 'inputOutput' ) ] .
+# initializeOnly "A field with accessType initializeOnly can be initialized, but cannot send or receive events."
+# inputOnly "A field with accessType inputOnly cannot be initialized or included in a scene file, but can receive input event values via a ROUTE."
+# outputOnly "A field with accessType outputOnly cannot be initialized or included in a scene file, but can send output event values via a ROUTE."
+# inputOutput "A field with accessType inputOutput can be initialized, and can also send or receive events."
+
+:appliedParametersChoices rdf:type rdfs:Datatype ;
+  rdfs:label "appliedParametersChoices" ;
+  dc:description "Default global parameters for collision outputs of rigid body physics system" ;
+  rdfs:range :MFString .
+#  rdfs:domain [ owl:unionOf (  '"BOUNCE"' '"USER_FRICTION"' '"FRICTION_COEFFICIENT-2"' '"ERROR_REDUCTION"' '"CONSTANT_FORCE"' '"SPEED-1"' '"SPEED-2"' '"SLIP-1"' '"SLIP-2"' ) ] .
+# "BOUNCE" "The bounce field value is used."
+# "USER_FRICTION" "The system will normally calculate the friction direction vector that is perpendicular to the contact normal. This setting indicates that the user-supplied value in this contact should be used."
+# "FRICTION_COEFFICIENT-2" "Apply frictionCoefficients values"
+# "ERROR_REDUCTION" "Apply softnessErrorCorrection value"
+# "CONSTANT_FORCE" "Apply softnessConstantForceMix value"
+# "SPEED-1" "Apply first component of surfaceSpeed array"
+# "SPEED-2" "Apply second component of surfaceSpeed array"
+# "SLIP-1" "Apply first component of slipFactors array"
+# "SLIP-2" "Apply second component of slipFactors array"
+
+:bboxSizeType rdf:type rdfs:Datatype ;
+  rdfs:label "bboxSizeType" ;
+  dc:description "bboxSizeType dimensions are non-negative values, default value (-1 -1 -1) indicates that no bounding box size has been computed" ;
+  rdfs:range :SFVec3f .
+
+:closureTypeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "closureTypeChoices" ;
+  dc:description "closureTypeChoices are strictly allowed enumeration values for ArcClose2D closureType field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'PIE' 'CHORD' ) ] .
+# PIE "Connects arc endpoints to center, forming a pie wedge"
+# CHORD "Connects arc endpoints directly to each other, as in chord on a circle"
+
+:colorModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "colorModeChoices" ;
+  dc:description "colorModeChoices are strictly allowed enumeration values for PointProperties colorMode field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'POINT_COLOR' 'TEXTURE_COLOR' 'TEXTURE_AND_POINT_COLOR' ) ] .
+# POINT_COLOR "RGB color of Material or Color, with alpha of texture"
+# TEXTURE_COLOR "Texture color only"
+# TEXTURE_AND_POINT_COLOR "Combined RGB color of texture with Material or Color, with alpha of texture"
+
+:componentNameChoices rdf:type rdfs:Datatype ;
+  rdfs:label "componentNameChoices" ;
+  dc:description "componentNameChoices are enumeration constants used to identify the profile for each scene-graph node, and also utilized by X3D element to identify the components required by the contained Scene" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'Core' 'CADGeometry' 'CubeMapTexturing' 'DIS' 'EnvironmentalEffects' 'EnvironmentalSensor' 'EventUtilities' 'Followers' 'Geometry2D' 'Geometry3D' 'Geospatial' 'Grouping' 'HAnim' 'H-Anim' 'Interpolation' 'KeyDeviceSensor' 'Layering' 'Layout' 'Lighting' 'Navigation' 'Networking' 'NURBS' 'ParticleSystems' 'Picking' 'PointingDeviceSensor' 'Rendering' 'RigidBodyPhysics' 'Scripting' 'Shaders' 'Shape' 'Sound' 'Text' 'Texturing' 'Texturing3D' 'Time' 'VolumeRendering' ) ] .
+# Core "The Core component supplies the base functionality for the X3D run-time system, including the abstract base node type, field types, the event model, and routing."
+# CADGeometry "The CADGeometry component is provided for Computer-Aided Design (CAD) nodes."
+# CubeMapTexturing "The Cube Map Environmental Texturing component describes how additional texturing effects are defined to produce environmental effects such as reflections from objects."
+# DIS "The Distributed Interactive Simulation (DIS) component provides networked interoperability with the IEEE DIS protocol for sharing state and conducting real-time platform-level simulations across multiple host computers."
+# EnvironmentalEffects "Nodes in the Environmental effects component support the creation of realistic environmental effects such as panoramic backgrounds and fog."
+# EnvironmentalSensor "The Environment Sensor nodes emit events indicating activity in the scene environment, usually based on interactions between the viewer and the world."
+# EventUtilities "The Event Utility nodes provide the capability to filter, trigger, convert, or sequence numerous event-types for common interactive applications without the use of a Script node."
+# Followers "The Follower nodes (Chasers and Dampers) support dynamic creation of smooth parameter transitions at run time."
+# Geometry2D "The Geometry2D component defines how two-dimensional geometry is specified and what shapes are available."
+# Geometry3D "The Geometry3D component describes how three-dimensional geometry is specified and defines ElevationGrid, Extrusion, IndexedFaceSet, and most primitive geometry nodes (Box, Cone, Cylinder, Sphere)."
+# Geospatial "The Geospatial component defines how to associate real-world locations in an X3D scene and specifies nodes particularly tuned for geospatial applications."
+# Grouping "The Grouping component describes how nodes are organized into groups to establish a transformation hierarchy for the X3D scene graph."
+# HAnim "The Humanoid Animation (HAnim) component for X3D defines node bindings and other details for implementing ISO/IEC 19774, the HAnim International Specification."
+# H-Anim "Legacy enumeration H-Anim for X3Dv3 provides backwards compatibility with Humanoid Animation (HAnim) version 1, preferred form is HAnim."
+# Interpolation "Interpolator nodes provide keyframe-based animation capability."
+# KeyDeviceSensor "The Key Device Sensor defines how keyboard keystrokes are inserted into an X3D world."
+# Layering "The Layering component describes how to layer a set of subscene layers into a composite scene."
+# Layout "The Layout component defines how to precisely position content in a scene in relation to the rendered results, especially for integrating 2D content with 3D content."
+# Lighting "The Lighting component specifies how light sources are defined and positioned, as well as how lights effect the rendered image."
+# Navigation "The Navigation component specifies how a user can effectively and intuitively move through and around a 3D scene."
+# Networking "The Networking component defines node types and other features used to access file-based and streaming resources on the World Wide Web."
+# NURBS "The NURBS component describes Non-uniform Rational B-Spline (NURBS) geometry and interpolation nodes."
+# ParticleSystems "The Particle Systems component specifies how to model particles and their interactions through the application of basic physics principles to affect motion."
+# Picking "The Picking component provides the ability to test for arbitrary object collision and provide basic capabilities to detecting object intersections and interactions."
+# PointingDeviceSensor "Pointing device sensor nodes detect pointing events from user-interface devices, defining activities such as a user selecting a piece of geometry."
+# Rendering "The Rendering component includes fundamental rendering primitives such as TriangleSet and PointSet nodes, as well as geometric properties nodes that define how coordinate indices, colors, normals and texture coordinates are specified."
+# RigidBodyPhysics "The Rigid Body Physics component describes how to model rigid bodies and their interactions through the application of basic physics principles to effect motion."
+# Scripting "The Script component describes how Script nodes are used to effect changes in X3D worlds."
+# Shaders "The programmable shaders component describes how programmable shaders are specified and how they affect the visual appearance of geometry."
+# Shape "The Shape component defines nodes for associating geometry with their visible properties and the scene environment."
+# Sound "The Sound component defines how sound is delivered to an X3D world as well as how sounds are accessed."
+# Text "The Text component defines how text strings are rendered in an X3D scene."
+# Texturing "The Texturing component specifies how 2D texture images are defined and then positioned on associated geometry."
+# Texturing3D "The Texturing3D component specifies how 3D volumetric textures describe surface properties as data points in a volume of space, rather than a flat surface."
+# Time "The Time component defines how time is sensed, computed and associated with events in an X3D scene."
+# VolumeRendering "The Volume Rendering component provides the ability to specify and render volumetric data sets."
+
+:fieldTypeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "fieldTypeChoices" ;
+  dc:description "fieldTypeChoices are enumerations for all allowed names of X3DField types" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'SFBool' 'MFBool' 'SFColor' 'MFColor' 'SFColorRGBA' 'MFColorRGBA' 'SFDouble' 'MFDouble' 'SFFloat' 'MFFloat' 'SFImage' 'MFImage' 'SFInt32' 'MFInt32' 'SFNode' 'MFNode' 'SFRotation' 'MFRotation' 'SFString' 'MFString' 'SFTime' 'MFTime' 'SFVec2d' 'MFVec2d' 'SFVec2f' 'MFVec2f' 'SFVec3d' 'MFVec3d' 'SFVec3f' 'MFVec3f' 'SFVec4d' 'MFVec4d' 'SFVec4f' 'MFVec4f' 'SFMatrix3d' 'MFMatrix3d' 'SFMatrix3f' 'MFMatrix3f' 'SFMatrix4d' 'MFMatrix4d' 'SFMatrix4f' 'MFMatrix4f' ) ] .
+# SFBool "Single Field (singleton) Boolean"
+# MFBool "Multiple Field (list) Boolean"
+# SFColor "Single Field (singleton) color value, red-green-blue"
+# MFColor "Multiple Field (list) color value, red-green-blue"
+# SFColorRGBA "Single Field (singleton) color value, red-green-blue alpha (opacity)"
+# MFColorRGBA "Multiple Field (list) color value, red-green-blue alpha (opacity)"
+# SFDouble "Single Field (singleton) double-precision (64-bit) float"
+# MFDouble "Multiple Field (list) 2-tuple double-precision (64-bit) float vector"
+# SFFloat "Single Field (singleton) single-precision (32-bit) float"
+# MFFloat "Multiple Field (list) single-precision (32-bit) float vector"
+# SFImage "Single Field (singleton) image value"
+# MFImage "Multiple Field (list) image values"
+# SFInt32 "Single Field (singleton) 32-bit integer"
+# MFInt32 "Multiple Field (list) 32-bit integer"
+# SFNode "Single Field (singleton) node"
+# MFNode "Multiple Field (list) nodes"
+# SFRotation "Single Field (singleton) rotation value using 3-tuple axis, radian angle"
+# MFRotation "Multiple Field (list) rotation values using 3-tuple axis, radian angle"
+# SFString "Single Field (singleton) string value"
+# MFString "Multiple Field (list) SFString array"
+# SFTime "Single Field (singleton) time value in seconds"
+# MFTime "Multiple Field (list) time array in seconds"
+# SFVec2d "Single Field (singleton) 2-tuple double-precision float vector"
+# MFVec2d "Multiple Field (list) 2-tuple double-precision float vectors"
+# SFVec2f "Single Field (singleton) 2-tuple single-precision float vector"
+# MFVec2f "Multiple Field (list) 2-tuple single-precision float vectors"
+# SFVec3d "Single Field (singleton) 3-tuple double-precision float vector"
+# MFVec3d "Multiple Field (list) 3-tuple double-precision float vectors"
+# SFVec3f "Single Field (singleton) 3-tuple single-precision float vector"
+# MFVec3f "Multiple Field (list) 3-tuple single-precision float vectors"
+# SFVec4d "Single Field (singleton) 4-tuple double-precision float vector"
+# MFVec4d "Multiple Field (list) 4-tuple double-precision float vectors"
+# SFVec4f "Single Field (singleton) 4-tuple single-precision float vector"
+# MFVec4f "Multiple Field (list) 4-tuple single-precision float vectors"
+# SFMatrix3d "Single Field (singleton) 3×3 matrix of double-precision floating point numbers"
+# MFMatrix3d "Multiple Field (list) 3×3 matrices of double-precision floating point numbers"
+# SFMatrix3f "Single Field (singleton) 3×3 matrix of single-precision floating point numbers"
+# MFMatrix3f "Multiple Field (list) 3×3 matrices of double-precision floating point numbers"
+# SFMatrix4d "Single Field (singleton) 4×4 matrix of double-precision floating point numbers"
+# MFMatrix4d "Multiple Field (list) 4×4 matric3w of double-precision floating point numbers"
+# SFMatrix4f "Single Field (singleton) 4×4 matrix of single-precision floating point numbers"
+# MFMatrix4f "Multiple Field (list) 4×4 matrices of single-precision floating point numbers"
+
+:fogTypeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "fogTypeChoices" ;
+  dc:description "fogTypeChoices are strictly allowed enumeration values for Fog node fogType field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'LINEAR' 'EXPONENTIAL' ) ] .
+# LINEAR "linear blending as a function of distance"
+# EXPONENTIAL "exponential blending as a function of distance"
+
+:fontFamilyValues rdf:type rdfs:Datatype ;
+  rdfs:label "fontFamilyValues" ;
+  dc:description "fontFamilyValues are allowed enumeration values for FontStyle/ScreenFontStyle node family field" ;
+  rdfs:range :MFString .
+#  rdfs:domain [ owl:unionOf (  '"SANS"' '"SERIF"' '"TYPEWRITER"' ) ] .
+# "SANS" "default font family for sans-serif font such as Helvetica"
+# "SERIF" "default font family for serif font such as Times-Roman"
+# "TYPEWRITER" "default font family for a fixed-pitch font such as Courier"
+
+:fontStyleChoices rdf:type rdfs:Datatype ;
+  rdfs:label "fontStyleChoices" ;
+  dc:description "fontStyleChoices are strictly allowed enumeration values for FontStyle/ScreenFontStyle node style field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'PLAIN' 'BOLD' 'ITALIC' 'BOLDITALIC' ) ] .
+# PLAIN "default plain type"
+# BOLD "boldface type"
+# ITALIC "italic type"
+# BOLDITALIC "bold and italic type"
+
+:forceOutputValues rdf:type rdfs:Datatype ;
+  rdfs:label "forceOutputValues" ;
+  dc:description "forceOutputValues are suggested values for X3DRigidJointNode type forceOutput field" ;
+  rdfs:range :MFString .
+#  rdfs:domain [ owl:unionOf (  '"ALL"' '"NONE"' ) ] .
+# "ALL" "all forceOutput fields computed"
+# "NONE" "no forceOutput fields computed"
+
+:generatedCubeMapTextureUpdateChoices rdf:type rdfs:Datatype ;
+  rdfs:label "generatedCubeMapTextureUpdateChoices" ;
+  dc:description "generatedCubeMapTextureUpdateChoices are strictly allowed enumeration values for GeneratedCubeMapTexture field named 'update'" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'NONE' 'NEXT_FRAME_ONLY' 'ALWAYS' ) ] .
+# NONE "no further texture updates are rendered"
+# NEXT_FRAME_ONLY "render texture once at end of frame"
+# ALWAYS "texture to be rendered every frame"
+
+:geoMetadataKeyValues rdf:type rdfs:Datatype ;
+  rdfs:label "geoMetadataKeyValues" ;
+  dc:description "" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'title' 'description' 'coordinateSystem' 'horizontalDatum' 'verticalDatum' 'ellipsoid' 'extent' 'resolution' 'originator' 'copyright' 'date' 'metadataFormat' 'dataUrl' 'dataFormat' ) ] .
+
+:geoSystemType rdf:type rdfs:Datatype ;
+  rdfs:label "geoSystemType" ;
+  rdfs:range :MFString .
+
+:geoSystemValues rdf:type rdfs:Datatype ;
+  rdfs:label "geoSystemValues" ;
+  dc:description "The allowed values of spatial reference frames and earth ellipsoids" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'GD' 'GC' 'UTM' 'AM' 'AN' 'BN' 'BR' 'CC' 'CD' 'EA' 'EB' 'EC' 'ED' 'EE' 'EF' 'FA' 'HE' 'HO' 'ID' 'IN' 'KA' 'RF' 'SA' 'WD' 'WE' 'WGS84' 'Zn' 'S' ) ] .
+# GD "Geodetic spatial reference frame"
+# GC "Geocentric spatial reference frame"
+# UTM "Universal Transverse Mercator"
+# AM "Modified Airy"
+# AN "Australian National"
+# BN "Bessel 1841 (Namibia)"
+# BR "Bessel 1841 (Ethiopia Indonesia ...)"
+# CC "Clarke 1866"
+# CD "Clarke 1880"
+# EA "Everest (India 1830)"
+# EB "Everest (Sabah & Sarawak)"
+# EC "Everest (India 1956)"
+# ED "Everest (W. Malaysia 1969)"
+# EE "Everest (W. Malaysia & Singapore 1948)"
+# EF "Everest (Pakistan)"
+# FA "Modified Fischer 1960"
+# HE "Helmert 1906"
+# HO "Hough 1960"
+# ID "Indonesia 1974"
+# IN "International 1924"
+# KA "Krassovsky 1940"
+# RF "Geodetic Reference System 1980 (GRS 80)"
+# SA "South American 1969"
+# WD "WGS 72"
+# WE "WGS 84"
+# WGS84 "WGS84 geoid"
+# Zn "Zone number (1..60) (only used with UTM)"
+# S "Southern hemisphere (only used with UTM)"
+
+:hanimFeaturePointNameValues rdf:type rdfs:Datatype ;
+  rdfs:label "hanimFeaturePointNameValues" ;
+  dc:description "Feature point names for identification of HAnimSite/HAnimDIsplacer nodes as defined in the HAnim Architecture specification" ;
+  rdfs:range xs:NMTOKEN .
+  #rdfs:domain [ owl:unionOf ( 'skull_vertex' 'glabella' 'sellion' 'l_infraorbitale' 'l_tragion' 'l_gonion' 'r_infraorbitale' 'r_tragion' 'r_gonion' 'supramenton' 'cervicale' 'adams_apple' 'suprasternale' 'substernale' 'l_clavicle' 'l_acromion' 'l_axilla_proximal' 'l_axilla_distal' 'l_axilla_posterior_folds' 'r_clavicle' 'r_acromion' 'r_axilla_proximal' 'r_axilla_distal' 'r_axilla_posterior_folds' 'spine_1_middle_back' 'spine_2_lower_back' 'waist_preferred_anterior' 'waist_preferred_posterior' 'l_rib10' 'l_thelion' 'r_rib10' 'r_thelion' 'l_asis' 'l_iliocristale' 'l_psis' 'r_asis' 'r_iliocristale' 'r_psis' 'crotch' 'l_femoral_lateral_epicondyle' 'l_femoral_medial_epicondyle' 'l_suprapatella' 'l_trochanterion' 'r_femoral_lateral_epicondyle' 'r_femoral_medial_epicondyle' 'r_suprapatella' 'r_trochanterion' 'l_tibiale' 'l_medial_malleolus' 'l_lateral_malleolus' 'l_sphyrion' 'r_tibiale' 'r_medial_malleolus' 'r_lateral_malleolus' 'r_sphyrion' 'l_metatarsal_phalanx_1' 'l_metatarsal_phalanx_5' 'l_dactylion' 'l_calcaneus_posterior' 'r_metatarsal_phalanx_1' 'r_metatarsal_phalanx_5' 'r_dactylion' 'r_calcaneus_posterior' 'l_humeral_lateral_epicondyle' 'l_humeral_medial_epicondyle' 'l_olecranon' 'r_humeral_lateral_epicondyle' 'r_humeral_medial_epicondyle' 'r_olecranon' 'l_radiale' 'l_ulnar_styloid' 'l_radial_styloid' 'r_radiale' 'r_ulnar_styloid' 'r_radial_styloid' 'l_metacarpal_phalanx_2' 'l_metacarpal_phalanx_3' 'l_metacarpal_phalanx_5' 'r_metacarpal_phalanx_2' 'r_metacarpal_phalanx_3' 'r_metacarpal_phalanx_5' 'nuchale' 'l_neck_base' 'r_neck_base' 'navel' 'l_ectocanthus' 'r_ectocanthus' 'menton' 'mesosternale' 'opisthocranion' 'l_knee_crease' 'r_knee_crease' 'rear_center_midsagittal_plane' 'buttocks_standing_wall_contact_point' 'l_chest_midsagittal_plane' 'r_chest_midsagittal_plane' 'l_bideltoid' 'r_bideltoid' 'l_carpal_distal_phalanx_1' 'l_carpal_distal_phalanx_2' 'l_carpal_distal_phalanx_3' 'l_carpal_distal_phalanx_4' 'l_carpal_distal_phalanx_5' 'r_carpal_distal_phalanx_1' 'r_carpal_distal_phalanx_2' 'r_carpal_distal_phalanx_3' 'r_carpal_distal_phalanx_4' 'r_carpal_distal_phalanx_5' 'l_tarsal_distal_phalanx_1' 'l_tarsal_distal_phalanx_2' 'l_tarsal_distal_phalanx_3' 'l_tarsal_distal_phalanx_4' 'l_tarsal_distal_phalanx_5' 'r_tarsal_distal_phalanx_1' 'r_tarsal_distal_phalanx_2' 'r_tarsal_distal_phalanx_3' 'r_tarsal_distal_phalanx_4' 'r_tarsal_distal_phalanx_5' ) ] .
+# skull_vertex "CAESAR 2003 skull_vertex matches ISO 7250-1 part 5.22 Vertex (top of head). No corresponding landmark provided in CAESAR 2018."
+# glabella "glabella is between the eyebrows and above the nose"
+# sellion "osseocartilaginous junction of the nasal dorsum"
+# l_infraorbitale "Left Infraorbitale foramen is opening in maxillary bone of skull located below the infraorbital margin of the orbit."
+# l_tragion "notch just above the tragus of the ear"
+# l_gonion "Left Gonion is midpoint of mandibular angle of the jaw."
+# r_infraorbitale "Right Infraorbitale foramen is opening in maxillary bone of skull located below the infraorbital margin of the orbit."
+# r_tragion "notch just above the tragus of the ear"
+# r_gonion "Right Gonion is midpoint of the mandibular angle of the jaw."
+# supramenton "center point above tip of chin"
+# suprasternale "Suprasternale"
+# l_axilla_proximal "Left Axilla Proximal (Anterior)"
+# l_axilla_distal "Left Axilla Distal (Posterior)"
+# r_axilla_proximal "Right Axilla Proximal (Anterior)"
+# r_axilla_distal "Right Axilla Distal (Posterior)"
+# r_axilla_posterior_folds "Right Posterior Axillary Folds"
+
+:hanimHumanoidInfoKeyValues rdf:type rdfs:Datatype ;
+  rdfs:label "hanimHumanoidInfoKeyValues" ;
+  rdfs:range xs:NMTOKEN  .
+  #rdfs:domain [ owl:unionOf ( 'authorName' 'authorEmail' 'copyright' 'creationDate' 'usageRestrictions' 'humanoidVersion' 'age' 'gender' 'height' 'weight' ) ] .
+
+:hanimJointNameValues rdf:type rdfs:Datatype ;
+  rdfs:label "hanimJointNameValues" ;
+  dc:description "CAESAR joint names for identification of HAnimJoint nodes as defined in the HAnim Architecture specification" ;
+  rdfs:range xs:NMTOKEN .
+  #rdfs:domain [ owl:unionOf ( 'humanoid_root' 'sacroiliac' 'l_hip' 'l_knee' 'l_talocrural' 'l_talocalcaneonavicular' 'l_cuneonavicular_1' 'l_tarsometatarsal_1' 'l_metatarsophalangeal_1' 'l_tarsal_interphalangeal_1' 'l_cuneonavicular_2' 'l_tarsometatarsal_2' 'l_metatarsophalangeal_2' 'l_tarsal_proximal_interphalangeal_2' 'l_tarsal_distal_interphalangeal_2' 'l_cuneonavicular_3' 'l_tarsometatarsal_3' 'l_metatarsophalangeal_3' 'l_tarsal_proximal_interphalangeal_3' 'l_tarsal_distal_interphalangeal_3' 'l_calcaneocuboid' 'l_transversetarsal' 'l_tarsometatarsal_4' 'l_metatarsophalangeal_4' 'l_tarsal_proximal_interphalangeal_4' 'l_tarsal_distal_interphalangeal_4' 'l_tarsometatarsal_5' 'l_metatarsophalangeal_5' 'l_tarsal_proximal_interphalangeal_5' 'l_tarsal_distal_interphalangeal_5' 'r_hip' 'r_knee' 'r_talocrural' 'r_talocalcaneonavicular' 'r_cuneonavicular_1' 'r_tarsometatarsal_1' 'r_metatarsophalangeal_1' 'r_tarsal_interphalangeal_1' 'r_cuneonavicular_2' 'r_tarsometatarsal_2' 'r_metatarsophalangeal_2' 'r_tarsal_proximal_interphalangeal_2' 'r_tarsal_distal_interphalangeal_2' 'r_cuneonavicular_3' 'r_tarsometatarsal_3' 'r_metatarsophalangeal_3' 'r_tarsal_proximal_interphalangeal_3' 'r_tarsal_distal_interphalangeal_3' 'r_calcaneocuboid' 'r_transversetarsal' 'r_tarsometatarsal_4' 'r_metatarsophalangeal_4' 'r_tarsal_proximal_interphalangeal_4' 'r_tarsal_distal_interphalangeal_4' 'r_tarsometatarsal_5' 'r_metatarsophalangeal_5' 'r_tarsal_proximal_interphalangeal_5' 'r_tarsal_distal_interphalangeal_5' 'vl5' 'vl4' 'vl3' 'vl2' 'vl1' 'vt12' 'vt11' 'vt10' 'vt9' 'vt8' 'vt7' 'vt6' 'vt5' 'vt4' 'vt3' 'vt2' 'vt1' 'vc7' 'vc6' 'vc5' 'vc4' 'vc3' 'vc2' 'vc1' 'skullbase' 'l_eyelid_joint' 'r_eyelid_joint' 'l_eyeball_joint' 'r_eyeball_joint' 'l_eyebrow_joint' 'r_eyebrow_joint' 'temporomandibular' 'l_sternoclavicular' 'l_acromioclavicular' 'l_shoulder' 'l_elbow' 'l_radiocarpal' 'l_midcarpal_1' 'l_carpometacarpal_1' 'l_metacarpophalangeal_1' 'l_carpal_interphalangeal_1' 'l_midcarpal_2' 'l_carpometacarpal_2' 'l_metacarpophalangeal_2' 'l_carpal_proximal_interphalangeal_2' 'l_carpal_distal_interphalangeal_2' 'l_midcarpal_3' 'l_carpometacarpal_3' 'l_metacarpophalangeal_3' 'l_carpal_proximal_interphalangeal_3' 'l_carpal_distal_interphalangeal_3' 'l_midcarpal_4_5' 'l_carpometacarpal_4' 'l_metacarpophalangeal_4' 'l_carpal_proximal_interphalangeal_4' 'l_carpal_distal_interphalangeal_4' 'l_carpometacarpal_5' 'l_metacarpophalangeal_5' 'l_carpal_proximal_interphalangeal_5' 'l_carpal_distal_interphalangeal_5' 'r_sternoclavicular' 'r_acromioclavicular' 'r_shoulder' 'r_elbow' 'r_radiocarpal' 'r_midcarpal_1' 'r_carpometacarpal_1' 'r_metacarpophalangeal_1' 'r_carpal_interphalangeal_1' 'r_midcarpal_2' 'r_carpometacarpal_2' 'r_metacarpophalangeal_2' 'r_carpal_proximal_interphalangeal_2' 'r_carpal_distal_interphalangeal_2' 'r_midcarpal_3' 'r_carpometacarpal_3' 'r_metacarpophalangeal_3' 'r_carpal_proximal_interphalangeal_3' 'r_carpal_distal_interphalangeal_3' 'r_midcarpal_4_5' 'r_carpometacarpal_4' 'r_metacarpophalangeal_4' 'r_carpal_proximal_interphalangeal_4' 'r_carpal_distal_interphalangeal_4' 'r_carpometacarpal_5' 'r_metacarpophalangeal_5' 'r_carpal_proximal_interphalangeal_5' 'r_carpal_distal_interphalangeal_5' ) ] .
+
+:hanimSegmentNameValues rdf:type rdfs:Datatype ;
+  rdfs:label "hanimSegmentNameValues" ;
+  dc:description "CAESAR segment names for identification of HAnimSegment nodes as defined in the HAnim Architecture specification" ;
+  rdfs:range xs:NMTOKEN .
+  #rdfs:domain [ owl:unionOf ( 'sacrum' 'pelvis' 'l_thigh' 'l_calf' 'l_talus' 'l_navicular' 'l_cuneiform_1' 'l_metatarsal_1' 'l_tarsal_proximal_phalanx_1' 'l_tarsal_distal_phalanx_1' 'l_cuneiform_2' 'l_metatarsal_2' 'l_tarsal_proximal_phalanx_2' 'l_tarsal_middle_phalanx_2' 'l_tarsal_distal_phalanx_2' 'l_cuneiform_3' 'l_metatarsal_3' 'l_tarsal_proximal_phalanx_3' 'l_tarsal_middle_phalanx_3' 'l_tarsal_distal_phalanx_3' 'l_calcaneus' 'l_cuboid' 'l_metatarsal_4' 'l_tarsal_proximal_phalanx_4' 'l_tarsal_middle_phalanx_4' 'l_tarsal_distal_phalanx_4' 'l_metatarsal_5' 'l_tarsal_proximal_phalanx_5' 'l_tarsal_middle_phalanx_5' 'l_tarsal_distal_phalanx_5' 'r_thigh' 'r_calf' 'r_talus' 'r_navicular' 'r_cuneiform_1' 'r_metatarsal_1' 'r_tarsal_proximal_phalanx_1' 'r_tarsal_distal_phalanx_1' 'r_cuneiform_2' 'r_metatarsal_2' 'r_tarsal_proximal_phalanx_2' 'r_tarsal_middle_phalanx_2' 'r_tarsal_distal_phalanx_2' 'r_cuneiform_3' 'r_metatarsal_3' 'r_tarsal_proximal_phalanx_3' 'r_tarsal_middle_phalanx_3' 'r_tarsal_distal_phalanx_3' 'r_calcaneus' 'r_cuboid' 'r_metatarsal_4' 'r_tarsal_proximal_phalanx_4' 'r_tarsal_middle_phalanx_4' 'r_tarsal_distal_phalanx_4' 'r_metatarsal_5' 'r_tarsal_proximal_phalanx_5' 'r_tarsal_middle_phalanx_5' 'r_tarsal_distal_phalanx_5' 'l5' 'l4' 'l3' 'l2' 'l1' 't12' 't11' 't10' 't9' 't8' 't7' 't6' 't5' 't4' 't3' 't2' 't1' 'c7' 'c6' 'c5' 'c4' 'c3' 'c2' 'c1' 'skull' 'l_eyelid' 'r_eyelid' 'l_eyeball' 'r_eyeball' 'l_eyebrow' 'r_eyebrow' 'jaw' 'l_clavicle' 'l_scapula' 'l_upperarm' 'l_forearm' 'l_carpal' 'l_trapezium' 'l_metacarpal_1' 'l_carpal_proximal_phalanx_1' 'l_carpal_distal_phalanx_1' 'l_trapezoid' 'l_metacarpal_2' 'l_carpal_proximal_phalanx_2' 'l_carpal_middle_phalanx_2' 'l_carpal_distal_phalanx_2' 'l_capitate' 'l_metacarpal_3' 'l_carpal_proximal_phalanx_3' 'l_carpal_middle_phalanx_3' 'l_carpal_distal_phalanx_3' 'l_hamate' 'l_metacarpal_4' 'l_carpal_proximal_phalanx_4' 'l_carpal_middle_phalanx_4' 'l_carpal_distal_phalanx_4' 'l_metacarpal_5' 'l_carpal_proximal_phalanx_5' 'l_carpal_middle_phalanx_5' 'l_carpal_distal_phalanx_5' 'r_clavicle' 'r_scapula' 'r_upperarm' 'r_forearm' 'r_carpal' 'r_trapezium' 'r_metacarpal_1' 'r_carpal_proximal_phalanx_1' 'r_carpal_distal_phalanx_1' 'r_trapezoid' 'r_metacarpal_2' 'r_carpal_proximal_phalanx_2' 'r_carpal_middle_phalanx_2' 'r_carpal_distal_phalanx_2' 'r_capitate' 'r_metacarpal_3' 'r_carpal_proximal_phalanx_3' 'r_carpal_middle_phalanx_3' 'r_carpal_distal_phalanx_3' 'r_hamate' 'r_metacarpal_4' 'r_carpal_proximal_phalanx_4' 'r_carpal_middle_phalanx_4' 'r_carpal_distal_phalanx_4' 'r_metacarpal_5' 'r_carpal_proximal_phalanx_5' 'r_carpal_middle_phalanx_5' 'r_carpal_distal_phalanx_5' ) ] .
+
+:hanimVersionChoices rdf:type rdfs:Datatype ;
+  rdfs:label "hanimVersionChoices" ;
+  dc:description "hanimVersionChoices enumeration constants are used to identify the allowed versions for an HAnimHumanoid node" ;
+  rdfs:range xs:NMTOKEN .
+ # rdfs:domain [ owl:unionOf ( '1.0' '1.1' '2.0' ) ] .
+# 1.0 "International standard HAnim 19774 version 1 approved by ISO in 2006."
+# 1.1 "International standard HAnim 19774 version 1 amendment."
+# 2.0 "Draft revision standard HAnim 19774 version 2 under review by ISO in 2018."
+
+:intensityType rdf:type rdfs:Datatype ;
+  rdfs:label "intensityType" ;
+  dc:description "intensityType values are floats ranging [0" ;
+  rdfs:range :SFFloat .
+
+:intersectionTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "intersectionTypeValues" ;
+  dc:description "intersectionTypeValues are suggested values for X3DPickSensorNode type intersectionType field" ;
+  rdfs:range xs:NMTOKEN .
+ # rdfs:domain [ owl:unionOf ( 'BOUNDS' 'GEOMETRY' ) ] .
+# BOUNDS "TODO undefined in X3D specification"
+# GEOMETRY "TODO undefined in X3D specification"
+
+:justifyChoices rdf:type rdfs:Datatype ;
+  rdfs:label "justifyChoices" ;
+  dc:description "justifyChoices are strictly allowed enumeration values for FontStyle node justify field" ;
+  rdfs:range :MFString .
+  # rdfs:domain [ owl:unionOf ( '"MIDDLE"' '"MIDDLE" "BEGIN"' '"MIDDLE" "END"' '"MIDDLE" "FIRST"' '"MIDDLE" "MIDDLE"' '"BEGIN"' '"BEGIN" "BEGIN"' '"BEGIN" "END"' '"BEGIN" "FIRST"' '"BEGIN" "MIDDLE"' '"END"' '"END" "BEGIN"' '"END" "END"' '"END" "FIRST"' '"END" "MIDDLE"' '"FIRST"' '"FIRST" "BEGIN"' '"FIRST" "END"' '"FIRST" "FIRST"' '"FIRST" "MIDDLE"' ) ] .
+
+:layoutAlignChoices rdf:type rdfs:Datatype ;
+  rdfs:label "layoutAlignChoices" ;
+  dc:description "Permitted combinations of horizontal and vertical values for the align field in the Layout node" ;
+  rdfs:range :MFString .
+  # rdfs:domain [ owl:unionOf ( '"LEFT" "BOTTOM"' '"LEFT" "CENTER"' '"LEFT" "TOP"' '"CENTER" "BOTTOM"' '"CENTER" "CENTER"' '"CENTER" "TOP"' '"RIGHT" "BOTTOM"' '"RIGHT" "CENTER"' '"RIGHT" "TOP"' ) ] .
+
+:layoutScaleModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "layoutScaleModeChoices" ;
+  dc:description "Permitted combinations of horizontal and vertical values for the scaleMode field in the Layout node" ;
+  rdfs:range :MFString .
+  
+  # rdfs:domain [ owl:unionOf ( '"NONE" "NONE"' '"NONE" "FRACTION"' '"NONE" "STRETCH"' '"NONE" "PIXEL"' '"FRACTION" "NONE"' '"FRACTION" "FRACTION"' '"FRACTION" "STRETCH"' '"FRACTION" "PIXEL"' '"STRETCH" "NONE"' '"STRETCH" "FRACTION"' '"STRETCH" "STRETCH"' '"STRETCH" "PIXEL"' '"PIXEL" "NONE"' '"PIXEL" "FRACTION"' '"PIXEL" "STRETCH"' '"PIXEL" "PIXEL"' ) ] .
+
+:layoutUnitsChoices rdf:type rdfs:Datatype ;
+  rdfs:label "layoutUnitsChoices" ;
+  dc:description "Permitted combinations of horizontal and vertical values for the offsetUnits field in the Layout node" ;
+  rdfs:range :MFString .
+ # rdfs:domain [ owl:unionOf ( '"WORLD" "WORLD"' '"WORLD" "FRACTION"' '"WORLD" "PIXEL"' '"FRACTION" "WORLD"' '"FRACTION" "FRACTION"' '"FRACTION" "PIXEL"' '"PIXEL" "WORLD"' '"PIXEL" "FRACTION"' '"PIXEL" "PIXEL"' ) ] .
+
+:loaType rdf:type rdfs:Datatype ;
+  rdfs:label "loaType" ;
+  dc:description "Level Of Articulation 0" ;
+  rdfs:range :SFInt32 .
+
+:metaDirectionChoices rdf:type rdfs:Datatype ;
+  rdfs:label "metaDirectionChoices" ;
+  dc:description "metaDirectionChoices are strictly allowed enumeration values for meta element direction field" ;
+  rdfs:range xs:NMTOKEN .
+  #rdfs:domain [ owl:unionOf ( 'rtl' 'ltr' ) ] .
+# rtl "right-to-left"
+# ltr "left-to-right"
+
+:metaNameValues rdf:type rdfs:Datatype ;
+  rdfs:label "metaNameValues" ;
+  dc:description "metaNameValues are suggested optional values for meta element name field" ;
+  rdfs:range xs:NMTOKEN .
+  #rdfs:domain [ owl:unionOf ( 'accessRights' 'author' 'contributor' 'created' 'creator' 'description' 'disclaimer' 'drawing' 'error' 'generator' 'hint' 'identifier' 'Image' 'info' 'information' 'isVersionOf' 'keywords' 'license' 'mediator' 'modified' 'movie' 'MovingImage' 'original' 'photo' 'photograph' 'publisher' 'reference' 'requires' 'rights' 'robots' 'Sound' 'source' 'specificationSection' 'specificationUrl' 'subject' 'Text' 'title' 'TODO' 'translator' 'translated' 'version' 'warning' ) ] .
+# accessRights "permission required to access resource or security status"
+# author "name of individual author"
+# contributor "name of individual contributing to this resource"
+# created "date of initial version"
+# creator "name of original author"
+# description "summary overview describing this resource"
+# disclaimer "statement of denial or disavowal regarding potential claims or responsiblity"
+# drawing "name or reference link to a supporting drawing or sketch file"
+# error "information about an error (or known problem) that can prevent proper operation"
+# generator "authoring tool or translation tool"
+# hint "user hint about resource features or operation"
+# identifier "url address or unique Uniform Resource Identifier (URI) for resource"
+# Image "name or reference link to supporting image file"
+# info "additional info of interest"
+# information "additional information of interest"
+# isVersionOf "Related resource of which the described resource is a version, edition, or adaptation."
+# keywords "comma-separated tokens, each of which is a keyword of interest"
+# license "content or software license"
+# mediator "entity that mediates access to resource and for whom resource is intended or useful"
+# modified "date of modified version"
+# movie "name or reference link to supporting movie file (note that Dublin Core term is MovingImage)"
+# MovingImage "name or reference link to supporting movie"
+# original "name or reference link to original file or resource"
+# photo "name or reference link to supporting photo file (note that Dublin Core term is Image)"
+# photograph "name or reference link to supporting photograph file (note that Dublin Core term is Image)"
+# publisher "entity responsible for making the resource available"
+# reference "name or reference link to supporting reference"
+# requires "prerequisites for operation or viewing"
+# rights "intellectual property rights (IPR)"
+# robots "search engine and web-spider guidance value: noindex to block page indexing, nofollow to block following links"
+# Sound "name or reference link to supporting sound file"
+# source "related resource from which the described resource is derived"
+# specificationSection "title of relevant specification section"
+# specificationUrl "url for relevant specification section"
+# subject "search-index subject keywords, key phrases, or classification codes"
+# Text "resource consisting primarily of words for reading"
+# title "file name for this resource"
+# TODO "action item "to do" that still needs to be performed"
+# translator "name of person performing translation from another format or language"
+# translated "date of translation from another format or language"
+# version "current version number or ID of this resource"
+# warning "warning information about a known problem that impedes proper operation"
+
+:multiTextureFunctionValues rdf:type rdfs:Datatype ;
+  rdfs:label "multiTextureFunctionValues" ;
+  dc:description "multiTextureFunctionValues are allowed values for the MultiTexture node function attribute, one per each texture" ;
+  rdfs:range :MFString .
+ # rdfs:domain [ owl:unionOf ( '"COMPLEMENT"' '"ALPHAREPLICATE"' '""' ) ] .
+# "COMPLEMENT" "Invert argument x as (1 - x)"
+# "ALPHAREPLICATE" "Replicate alpha information to all color channels before operation completes."
+# "" "No function is applied - empty SFString is allowed value within MFString array"
+
+:multiTextureModeValues rdf:type rdfs:Datatype ;
+  rdfs:label "multiTextureModeValues" ;
+  dc:description "multiTextureModeValues are allowed values for the MultiTexture mode attribute, one per each texture" ;
+  rdfs:range :MFString .
+ # rdfs:domain [ owl:unionOf ( '"ADD"' '"ADDSIGNED"' '"ADDSIGNED2X"' '"ADDSMOOTH"' '"BLENDCURRENTALPHA"' '"BLENDDIFFUSEALPHA"' '"BLENDFACTORALPHA"' '"BLENDTEXTUREALPHA"' '"DOTPRODUCT3"' '"MODULATE"' '"MODULATE2X"' '"MODULATE4X"' '"MODULATEALPHA_ADDCOLOR"' '"MODULATEINVALPHA_ADDCOLOR"' '"MODULATEINVCOLOR_ADDALPHA"' '"OFF"' '"REPLACE"' '"SELECTARG1"' '"SELECTARG2"' '"SUBTRACT"' ) ] .
+
+:multiTextureSourceValues rdf:type rdfs:Datatype ;
+  rdfs:label "multiTextureSourceValues" ;
+  dc:description "multiTextureSourceValues are allowed values for the MultiTexture node source attribute, one per each texture" ;
+  rdfs:range :MFString .
+  #rdfs:domain [ owl:unionOf ( '"DIFFUSE"' '"FACTOR"' '"SPECULAR"' '""' ) ] .
+
+:navigationTransitionTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "navigationTransitionTypeValues" ;
+  dc:description "Permitted values for the transitionType field in the NavigationInfo node" ;
+  rdfs:range :MFString .
+  #rdfs:domain [ owl:unionOf ( '"TELEPORT"' '"LINEAR"' '"ANIMATE"' ) ] .
+# "TELEPORT" "immediate transition"
+# "LINEAR" "transition may proceed directly through intervening objects"
+# "ANIMATE" "rowser-specific transition"
+
+:navigationTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "navigationTypeValues" ;
+  dc:description "Permitted values for the type field in the NavigationInfo node" ;
+  rdfs:range :MFString .
+  #rdfs:domain [ owl:unionOf ( '"ANY"' '"WALK"' '"EXAMINE"' '"FLY"' '"LOOKAT"' '"NONE"' '"EXPLORE"' ) ] .
+# "ANY" "browser can offer any type for user to choose"
+# "WALK" "free navigation, avatar remains on ground, collision detection"
+# "EXAMINE" "view an individual object by rotating view about center"
+# "FLY" "free navigation, collision detection"
+# "LOOKAT" "navigate to particular object"
+# "NONE" "disables all navigation interfaces"
+# "EXPLORE" "consistent keystroke navigation for both geospatial and Cartesian modes"
+
+:networkModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "networkModeChoices" ;
+  dc:description "networkModeChoices are strictly allowed enumeration values for DIS field networkMode" ;
+  rdfs:range xs:NMTOKEN .
+ # rdfs:domain [ owl:unionOf ( 'standAlone' 'networkReader' 'networkWriter' ) ] .
+# standAlone "ignore network but still respond to events in local scene"
+# networkReader "listen to network and read PDU packets at readInterval, act as remotely linked copy of entity"
+# networkWriter "send PDU packets to network at writeInterval, act as master entity"
+
+:particleSystemGeometryTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "particleSystemGeometryTypeValues" ;
+  dc:description "particleSystemGeometryTypeValues are allowed enumeration values for the ParticleSystem node geometryType field" ;
+  rdfs:range xs:NMTOKEN .
+ # rdfs:domain [ owl:unionOf ( 'LINE' 'POINT' 'QUAD' 'SPRITE' 'TRIANGLE' 'GEOMETRY' ) ] .
+# LINE "line is drawn along current velocity vector of particle"
+# POINT "point geometry is rendered at particle position"
+# QUAD "quad geometry is rendered at particle position facing direction traveled"
+# SPRITE "quad geometry is rendered at particle position facing screen"
+# TRIANGLE "pair of triangles creating quad geometry is rendered at particle position facing direction traveled"
+# GEOMETRY "geometry field is used for rendering each particle"
+
+:phaseFunctionValues rdf:type rdfs:Datatype ;
+  rdfs:label "phaseFunctionValues" ;
+  dc:description "Default values for the phaseFunction field in the ShadedVolumeStyle" ;
+  rdfs:range :SFString .
+#  rdfs:domain [ owl:unionOf (  'Henyey-Greenstein' 'NONE' ) ] .
+# Henyey-Greenstein "Henyey-Greenstein phase function for scattering model"
+# NONE "no scattering"
+
+:pickableObjectTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "pickableObjectTypeValues" ;
+  dc:description "Suggested values for the objectType field in the abstract types X3DPickableObject and X3DPickSensorNode" ;
+  rdfs:range :MFString .
+#  rdfs:domain [ owl:unionOf (  '"ALL"' '"NONE"' '"TERRAIN"' ) ] .
+# "ALL" "each node is available for picking"
+# "NONE" "no node is available for picking"
+# "TERRAIN" "TERRAIN is an example value"
+
+:pickSensorMatchCriterionChoices rdf:type rdfs:Datatype ;
+  rdfs:label "pickSensorMatchCriterionChoices" ;
+  dc:description "pickSensorMatchCriterionChoices are strictly allowed enumeration values for X3DPickSensorNode node matchCriterion field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'MATCH_ANY' 'MATCH_EVERY' 'MATCH_ONLY_ONE' ) ] .
+# MATCH_ANY "any match of objectType values is acceptable"
+# MATCH_EVERY "every objectType value in X3DPickSensorNode and X3DPickableObject shall match"
+# MATCH_ONLY_ONE "one and only one objectType value can match"
+
+:pickSensorSortOrderValues rdf:type rdfs:Datatype ;
+  rdfs:label "pickSensorSortOrderValues" ;
+  dc:description "pickSensorSortOrderValues are allowed enumeration values for X3DPickSensorNode node sortOrder field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'ANY' 'CLOSEST' 'ALL' 'ALL_SORTED' ) ] .
+# ANY "any single object that can satisfy picking conditions"
+# CLOSEST "return closest object by distance that satisfies conditions of this pick sensor"
+# ALL "every object that satisfies picking conditions for this pick sensor is returned"
+# ALL_SORTED "every object that satisfies picking conditions for this pick sensor is returned, in sorted order"
+
+:profileNameChoices rdf:type rdfs:Datatype ;
+  rdfs:label "profileNameChoices" ;
+  dc:description "profileNameChoices enumeration constants are used to identify the profile for each scene-graph node, and also utilized by X3D element to identify the profile of a contained Scene" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'Core' 'Interchange' 'CADInterchange' 'Interactive' 'Immersive' 'MedicalInterchange' 'MPEG4Interactive' 'Full' ) ] .
+# Core "Core Profile includes no nodes and is provided as the basis for custom componentization. Allowed X3D statements for all profiles are: connect ExternProtoDeclare EXPORT field fieldValue IMPORT IS ProtoBody ProtoDeclare ProtoInterface ProtoInstance ROUTE X3D. Allowed X3D nodes for this profile are: MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString."
+# Interchange "Interchange Profile equals the minimum subset of nodes needed to display lightweight compelling content. Allowed X3D nodes for this profile are: Appearance Background Box Color ColorInterpolator ColorRGBA Cone Coordinate CoordinateInterpolator Cylinder DirectionalLight Group ImageTexture IndexedFaceSet IndexedLineSet IndexedTriangleFanSet IndexedTriangleSet IndexedTriangleStripSet LineSet Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal NormalInterpolator OrientationInterpolator PixelTexture PointSet PositionInterpolator ScalarInterpolator Shape Sphere TextureCoordinate TextureCoordinateGenerator TextureTransform TimeSensor Transform TriangleFanSet TriangleSet TriangleStripSet Viewpoint WorldInfo."
+# CADInterchange "CADInterchange Profile adds support for CADGeometry component nodes to Interchange Profile. Allowed X3D nodes for this profile are: Anchor Appearance CADAssembly CADFace CADLayer CADPart Billboard Collision Color ColorRGBA Coordinate DirectionalLight FragmentShader Group ImageTexture IndexedLineSet IndexedQuadSet IndexedTriangleFanSet IndexedTriangleSet IndexedTriangleStripSet Inline LineProperties LineSet LOD Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MultiShader MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal PixelTexture PointSet QuadSet Shader ShaderAppearance Shape TextureCoordinate TextureCoordinateGenerator TextureTransform Transform TriangleFanSet TriangleSet TriangleStripSet Viewpoint VertexShader WorldInfo."
+# Interactive "Interactive Profile adds interaction nodes (Anchor, KeySensor) to the minimum subset of nodes needed to display lightweight compelling content. Allowed X3D nodes for this profile are: Anchor Appearance Background BooleanFilter BooleanSequencer BooleanToggle BooleanTrigger Box Color ColorInterpolator ColorRGBA Cone Coordinate CoordinateInterpolator Cylinder CylinderSensor DirectionalLight ElevationGrid Group ImageTexture IndexedFaceSet IndexedLineSet IndexedTriangleFanSet IndexedTriangleSet IndexedTriangleStripSet Inline IntegerSequencer IntegerTrigger KeySensor LineSet Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal NormalInterpolator OrientationInterpolator IndexedTriangleStripSet Inline IntegerSequencer IntegerTrigger KeySensor LineSet Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal NormalInterpolator OrientationInterpolator PixelTexture PlaneSensor PointLight PointSet PositionInterpolator ProximitySensor ScalarInterpolator Shape Sphere SphereSensor SpotLight StringSensor Switch TextureCoordinate TextureCoordinateGenerator TextureTransform TimeSensor TimeTrigger TouchSensor Transform TriangleFanSet TriangleSet TriangleStripSet Viewpoint VisibilitySensor WorldInfo."
+# Immersive "Immersive Profile equals all of the nodes in the VRML97 Specification, plus various X3D node additions including KeySensor, StringSensor and Scene. Allowed X3D nodes for this profile are: Anchor Appearance AudioClip Background Billboard BooleanFilter BooleanSequencer BooleanToggle BooleanTrigger Box Collision Color ColorInterpolator ColorRGBA Cone Coordinate CoordinateInterpolator Cylinder CylinderSensor DirectionalLight ElevationGrid Extrusion Fog FontStyle Group ImageTexture IndexedFaceSet IndexedLineSet IndexedTriangleFan IndexedTriangleSet IndexedTriangleStripSet Inline IntegerSequencer IntegerTrigger KeySensor LineProperties LineSet LoadSensor LOD Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MovieTexture MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal NormalInterpolator OrientationInterpolator PixelTexture PlaneSensor PointLight PointSet Polyline2D Polypoint2D PositionInterpolator ProximitySensor Rectangle2D ScalarInterpolator Script Shape Sound Sphere SphereSensor SpotLight StringSensor Switch Text TextureCoordinate TextureCoordinateGenerator TextureTransform TimeSensor TimeTrigger TouchSensor TriangleFanSet TriangleSet TriangleSet2D TriangleStripSet Transform Viewpoint VisibilitySensor WorldInfo."
+# MedicalInterchange "The MedicalInterchange profile adds support for VolumeRendering component to Interchange profile. Allowed X3D nodes for this profile are: Anchor Arc2D ArcClose2D Appearance Background Billboard BlendedVolumeStyle BooleanFilter BooleanSequencer BooleanToggle BooleanTrigger BoundaryEnhancementVolumeStyle Box CartoonVolumeStyle Circle2D ClipPlane Collision Color ColorInterpolator ColorRGBA ComposedVolumeStyle CompositeTexture3D Cone Coordinate CoordinateDouble CoordinateInterpolator Cylinder DirectionalLight Disk2D EdgeEnhancementVolumeStyle FillProperties FontStyle Group ImageTexture ImageTexture3D IndexedFaceSet IndexedLineSet IndexedTriangleFanSet IndexedTriangleSet IndexedTriangleStripSet Inline IntegerSequencer IntegerTrigger IsoSurfaceVolumeData LineProperties LineSet LOD Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString MultiTexture MultiTextureCoordinate MultiTextureTransform NavigationInfo Normal NormalInterpolator OctTree OpacityMapVolumeStyle OrientationInterpolator OrthoViewpoint PixelTexture PixelTexture3D PointSet Polyline2D Polypoint2D PositionInterpolator ProjectionVolumeStyle Rectangle2D ScalarInterpolator SegmentedVolumeData ShadedVolumeStyle Shape SilhouetteEnhancementVolumeStyle Sphere StaticGroup Switch Text TextureCoordinate TextureCoordinate3D TextureCoordinate4D TextureCoordinateGenerator TextureMatrixTransform TextureProperties TextureTransform TextureTransform3D TimeSensor TimeTrigger ToneMappedVolumeStyle Transform TriangleFanSet TriangleSet TriangleStripSet Viewpoint ViewpointGroup VolumeData WorldInfo."
+# MPEG4Interactive "MPEGInteractive Profile defines base interoperability with MPEG4 standards to a small subset of nodes needed to display lightweight compelling content. Allowed X3D nodes for this profile are: Anchor Appearance Background Box Color ColorInterpolator ColorRGBA Cone Coordinate CoordinateInterpolator Cylinder CylinderSensor DirectionalLight ElevationGrid Group ImageTexture IndexedFaceSet IndexedLineSet Inline LineSet Material MetadataBoolean MetadataDouble MetadataFloat MetadataInteger MetadataSet MetadataString NavigationInfo NormalInterpolator OrientationInterpolator PixelTexture PlaneSensor PointLight PointSet PositionInterpolator ProximitySensor ScalarInterpolator Shape Sphere SphereSensor SpotLight Switch TextureCoordinate TextureTransform TimeSensor TouchSensor Transform Viewpoint WorldInfo."
+# Full "The Full Profile corresponds to all Immersive X3D nodes plus all approved/implemented extensions. All X3D nodes and statements are allowed in this profile."
+
+:projectionVolumeStyleTypeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "projectionVolumeStyleTypeChoices" ;
+  dc:description "projectionVolumeStyleTypeChoices are strictly allowed enumeration values for ProjectionVolumeStyle field named 'type'" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'MAX' 'MIN' 'AVERAGE' ) ] .
+# MAX "Maximum Intensity Projection (MIP) or Least MIP (LMIP) algorithm is used to generate output color"
+# MIN "Minimum Intensity Projection algorithm is used to generate output color"
+# AVERAGE "All voxels along ray are averaged to generate output color"
+
+:shaderLanguageValues rdf:type rdfs:Datatype ;
+  rdfs:label "shaderLanguageValues" ;
+  dc:description "Suggested values for the language field in shader nodes include Cg GLSL HLSL, other values are optionally supported by browsers" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'Cg' 'GLSL' 'HLSL' ) ] .
+# Cg "nVidia Cg shading language"
+# GLSL "OpenGL shading language (GLSL)"
+# HLSL "Microsoft High Level Shading Language (HLSL)"
+
+:shaderPartTypeValues rdf:type rdfs:Datatype ;
+  rdfs:label "shaderPartTypeValues" ;
+  dc:description "shaderPartTypeValues are allowed enumeration values for ShaderPart type field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'VERTEX' 'FRAGMENT' ) ] .
+# VERTEX "vertex shader"
+# FRAGMENT "fragment shader"
+
+:textureBoundaryModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "textureBoundaryModeChoices" ;
+  dc:description "textureBoundaryModeChoices are strictly allowed enumeration values for TextureProperties boundaryMode* fields" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'CLAMP' 'CLAMP_TO_EDGE' 'CLAMP_TO_BOUNDARY' 'MIRRORED_REPEAT' 'REPEAT' ) ] .
+# CLAMP "Clamp texture coordinates to range [0,1]"
+# CLAMP_TO_EDGE "Clamp texture coordinates such that a border texel is never sampled"
+# CLAMP_TO_BOUNDARY "Clamp texture coordinates such that texture samples are border texels for fragments"
+# MIRRORED_REPEAT "Texture coordinates are mirrored and then clamped as in CLAMP_TO_EDGE"
+# REPEAT "Repeat a texture across the fragment"
+
+:textureCompressionModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "textureCompressionModeChoices" ;
+  dc:description "textureCompressionModeChoices are strictly allowed enumeration values for TextureProperties field textureCompression" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'DEFAULT' 'FASTEST' 'HIGH' 'LOW' 'MEDIUM' 'NICEST' ) ] .
+# DEFAULT "browser-specified default compression mode"
+# FASTEST "fastest method available"
+# HIGH "greatest amount of compression"
+# LOW "least amount of compression"
+# MEDIUM "moderate amount of compressions"
+# NICEST "highest quality method available"
+
+:textureCoordinateGeneratorModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "textureCoordinateGeneratorModeChoices" ;
+  dc:description "textureCoordinateGeneratorModeChoices are strictly allowed enumeration values for TextureCoordinateGenerator mode field" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'SPHERE' 'CAMERASPACENORMAL' 'CAMERASPACEPOSITION' 'CAMERASPACEREFLECTIONVECTOR' 'SPHERE-LOCAL' 'COORD' 'COORD-EYE' 'NOISE' 'NOISE-EYE' 'SPHERE-REFLECT' 'SPHERE-REFLECT-LOCAL' ) ] .
+# SPHERE "Creates texture coordinates for a spherical environment"
+# CAMERASPACENORMAL "Use vertex normal, transformed to camera space, as input texture coordinates"
+# CAMERASPACEPOSITION "Use vertex position, transformed to camera space, as input texture coordinates"
+# CAMERASPACEREFLECTIONVECTOR "Use reflection vector, transformed to camera space, as input texture coordinates"
+# SPHERE-LOCAL "Sphere mapping but in local coordinates"
+# COORD "Use vertex coordinates"
+# COORD-EYE "Use vertex coordinates transformed to camera space"
+# NOISE "Apply Perlin solid noise function on vertex coordinates"
+# NOISE-EYE "Apply Perlin solid noise function on vertex coordinates transformed to camera space"
+# SPHERE-REFLECT "similar to CAMERASPACEREFLECTIONVECTOR with optional index of refraction"
+# SPHERE-REFLECT-LOCAL "Similar to SPHERE-REFLECT transformed to camera space"
+
+:textureMagnificationModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "textureMagnificationModeChoices" ;
+  dc:description "textureMagnificationModeChoices are strictly allowed enumeration values for TextureProperties field magnificationFilter" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'AVG_PIXEL' 'DEFAULT' 'FASTEST' 'NEAREST_PIXEL' 'NICEST' ) ] .
+# AVG_PIXEL "weighted average of four texture elements closest to center of pixel being textured"
+# DEFAULT "browser-specified default magnification mode"
+# FASTEST "fastest method available"
+# NEAREST_PIXEL "texture element nearest to the center of pixel being textured"
+# NICEST "highest quality method available"
+
+:textureMinificationModeChoices rdf:type rdfs:Datatype ;
+  rdfs:label "textureMinificationModeChoices" ;
+  dc:description "textureMinificationModeChoices are strictly allowed enumeration values for TextureProperties field minificationFilter" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'AVG_PIXEL' 'AVG_PIXEL_AVG_MIPMAP' 'AVG_PIXEL_NEAREST_MIPMAP' 'DEFAULT' 'FASTEST' 'NEAREST_PIXEL' 'NEAREST_PIXEL_AVG_MIPMAP' 'NEAREST_PIXEL_NEAREST_MIPMAP' 'NICEST' ) ] .
+# AVG_PIXEL "weighted average of four texture elements closest to center of pixel being textured"
+# AVG_PIXEL_AVG_MIPMAP "tri-linear mipmap filtering"
+# AVG_PIXEL_NEAREST_MIPMAP "choose mipmap that most closely matches size of pixel being textured, use weighted average of four texture elements closest to center of pixel"
+# DEFAULT "browser-specified default minification mode"
+# FASTEST "fastest method available, use mipmaps if possible"
+# NEAREST_PIXEL "texture element nearest to center of pixel being textured"
+# NEAREST_PIXEL_AVG_MIPMAP "texture element nearest to center of pixel being textured, use average of two nearest mipmaps"
+# NEAREST_PIXEL_NEAREST_MIPMAP "texture element nearest to center of pixel being textured, use nearest mipmap"
+# NICEST "highest quality method available"
+
+:unitCategoryChoices rdf:type rdfs:Datatype ;
+  rdfs:label "unitCategoryChoices" ;
+  dc:description "unitCategoryChoices are strictly allowed enumeration values for standard units in the UNIT statement" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'angle' 'force' 'length' 'mass' ) ] .
+# angle "angle default is radians"
+# force "force default is newtons"
+# length "length default is meters"
+# mass "mass default is kilograms"
+
+:volumeRenderingWeightFunctionChoices rdf:type rdfs:Datatype ;
+  rdfs:label "volumeRenderingWeightFunctionChoices" ;
+  dc:description "volumeRenderingWeightFunctionChoices are strictly allowed enumeration values for BlendedVolumeStyle weightFunction* fields" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  'CONSTANT' 'ALPHA1' 'ALPHA2' 'ONE_MINUS_ALPHA1' 'ONE_MINUS_ALPHA2' 'TABLE' ) ] .
+# CONSTANT "Use weightConstant1"
+# ALPHA1 "Use O_v"
+# ALPHA2 "Use O_blend"
+# ONE_MINUS_ALPHA1 "Use 1 - O_v"
+# ONE_MINUS_ALPHA2 "Use 1 - O_blend"
+# TABLE "Use table lookup value"
+
+:x3dVersionChoices rdf:type rdfs:Datatype ;
+  rdfs:label "x3dVersionChoices" ;
+  dc:description "x3dVersionChoices enumeration string constants are used to identify the allowed versions for an X3D scene graph" ;
+  rdfs:range xs:NMTOKEN .
+#  rdfs:domain [ owl:unionOf (  '3.0' '3.1' '3.2' '3.3' '4.0' ) ] .
+# 3.0 "X3D version 3.0 approved by ISO in 2004."
+# 3.1 "X3D version 3.1 Amendment 1 approved by ISO in 2005. Backwards compatibility maintained with version 3.0."
+# 3.2 "X3D version 3.2 Amendment 2 approved by ISO in 2007. Backwards compatibility maintained with versions 3.0 and 3.1."
+# 3.3 "X3D version 3.3 approved by ISO in 2013 as International Standard (IS). Backwards compatibility maintained with versions 3.0, 3.1 and 3.2."
+# 4.0 "X3D version 4.0 under final development by Web3D Consortium. Backwards compatibility maintained with versions 3.0, 3.1, 3.2 and 3.3."
+
+###############################################
+
+# AbstractNodeTypes
+
+:X3DAppearanceChildNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Nodes of this type can be used as child nodes for Appearance." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DAppearanceNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Base type for all Appearance nodes." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DBackgroundNode a owl:Class ;
+  rdfs:subClassOf :X3DBindableNode ;
+  rdfs:label "Abstract type from which all backgrounds inherit, also defining a background binding stack." .
+:groundAngle a owl:DatatypeProperty ;
+  rdfs:label "X3DBackgroundNode field groundAngle is implemented by multiple nodes" ;
+ rdfs:domain [ owl:unionOf (  :X3DBackgroundNode :Background :TextureBackground ) ] ;
+  rdfs:range :MFFloat .
+:groundColor a owl:DatatypeProperty ;
+  rdfs:label "X3DBackgroundNode field groundColor is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DBackgroundNode :Background :TextureBackground ) ] ;
+  rdfs:range :MFColor .
+:skyAngle a owl:DatatypeProperty ;
+  rdfs:label "X3DBackgroundNode field skyAngle is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DBackgroundNode :Background :TextureBackground ) ] ;
+  rdfs:range :MFFloat .
+:skyColor a owl:DatatypeProperty ;
+  rdfs:label "X3DBackgroundNode field skyColor is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DBackgroundNode :Background :TextureBackground ) ] ;
+  rdfs:range :MFColor .
+:transparency a owl:DatatypeProperty ;
+  rdfs:label "X3DBackgroundNode field transparency is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DBackgroundNode :Background :TextureBackground ) ] ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DBindableNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Bindable nodes implement the binding stack, so that only one of each node type is active at a given time." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DChaserNode a owl:Class ;
+  rdfs:subClassOf :X3DFollowerNode ;
+  rdfs:label "The X3DChaserNode abstract node type calculates the output on value_changed as a finite impulse response (FIR) based on the events received on set_destination field." .
+:duration a owl:DatatypeProperty ;
+  rdfs:label "X3DChaserNode field duration is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DChaserNode :ColorChaser :CoordinateChaser :OrientationChaser :PositionChaser :PositionChaser2D :ScalarChaser :TexCoordChaser2D ) ] ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DChildNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "A node that implements X3DChildNode is one of the legal children for a X3DGroupingNode parent." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DColorNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "Base type for color specifications in X3D." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DComposableVolumeRenderStyleNode a owl:Class ;
+  rdfs:subClassOf :X3DVolumeRenderStyleNode ;
+  rdfs:label "The X3DComposableVolumeRenderStyleNode abstract node type is the base type for all node types that allow rendering styles to be sequentially composed together to form a single renderable output." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DComposedGeometryNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Composed geometry nodes produce renderable geometry, can contain Color Coordinate Normal TextureCoordinate, and are contained by a Shape node." .
+:attrib a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field attrib is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :X3DVertexAttributeNode ;
+  rdfs:subPropertyOf :hasChild .
+:ccw a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field ccw is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :SFBool .
+:color a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field color is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:colorPerVertex a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field colorPerVertex is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :SFBool .
+:coord a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field coord is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fogCoord a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field fogCoord is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :FogCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:normal a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field normal is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :X3DNormalNode ;
+  rdfs:subPropertyOf :hasChild .
+:normalPerVertex a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field normalPerVertex is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :SFBool .
+:solid a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field solid is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :SFBool .
+:texCoord a owl:DatatypeProperty ;
+  rdfs:label "X3DComposedGeometryNode field texCoord is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DComposedGeometryNode :IndexedFaceSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :QuadSet :TriangleFanSet :TriangleSet :TriangleStripSet ) ] ;
+  rdfs:range :X3DTextureCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DCoordinateNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "Base type for all coordinate node types in X3D." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DDamperNode a owl:Class ;
+  rdfs:subClassOf :X3DFollowerNode ;
+  rdfs:label "The X3DDamperNode abstract node type creates an IIR response that approaches the destination value according to the shape of the e-function only asymptotically but very quickly." .
+:order a owl:DatatypeProperty ;
+  rdfs:label "X3DDamperNode field order is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DDamperNode :ColorDamper :CoordinateDamper :OrientationDamper :PositionDamper :PositionDamper2D :ScalarDamper :TexCoordDamper2D ) ] ;
+  rdfs:range :SFInt32 .
+:tau a owl:DatatypeProperty ;
+  rdfs:label "X3DDamperNode field tau is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DDamperNode :ColorDamper :CoordinateDamper :OrientationDamper :PositionDamper :PositionDamper2D :ScalarDamper :TexCoordDamper2D ) ] ;
+  rdfs:range :SFTime .
+:tolerance a owl:DatatypeProperty ;
+  rdfs:label "X3DDamperNode field tolerance is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DDamperNode :ColorDamper :CoordinateDamper :OrientationDamper :PositionDamper :PositionDamper2D :ScalarDamper :TexCoordDamper2D ) ] ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DDragSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DPointingDeviceSensorNode ;
+  rdfs:label "Base type for all drag-style pointing device sensors." .
+:autoOffset a owl:DatatypeProperty ;
+  rdfs:label "X3DDragSensorNode field autoOffset is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DDragSensorNode :CylinderSensor :PlaneSensor :SphereSensor ) ] ;
+  rdfs:range :SFBool .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DEnvironmentalSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "Base type for the environmental sensor nodes ProximitySensor, TransformSensor and VisibilitySensor." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:size a owl:DatatypeProperty ;
+  rdfs:label "X3DEnvironmentalSensorNode field size is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DEnvironmentalSensorNode :GeoProximitySensor :ProximitySensor :TransformSensor :VisibilitySensor ) ] ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DEnvironmentTextureNode a owl:Class ;
+  rdfs:subClassOf :X3DTextureNode ;
+  rdfs:label "Base type for all nodes that specify cubic environment map sources for texture images." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DFollowerNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "X3DFollowerNode is the abstract base class for all nodes in the Followers component." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DFontStyleNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Base type for all font style nodes." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DGeometricPropertyNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Base type for all geometric property node types." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DGeometryNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Geometry nodes produce renderable geometry and are contained by a Shape node." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DGroupingNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "Grouping nodes can contain other nodes as children, thus making up the backbone of a scene graph." .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:label "X3DGroupingNode field bboxCenter is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DGroupingNode :X3DViewportNode :Anchor :Billboard :CADAssembly :CADLayer :CADPart :Collision :EspduTransform :GeoLocation :GeoTransform :Group :HAnimSegment :HAnimSite :LayoutGroup :LOD :PickableGroup :ScreenGroup :Switch :Transform :Viewport ) ] ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:label "X3DGroupingNode field bboxSize is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DGroupingNode :X3DViewportNode :Anchor :Billboard :CADAssembly :CADLayer :CADPart :Collision :EspduTransform :GeoLocation :GeoTransform :Group :HAnimSegment :HAnimSite :LayoutGroup :LOD :PickableGroup :ScreenGroup :Switch :Transform :Viewport ) ] ;
+  rdfs:range :SFVec3f .
+:children a owl:DatatypeProperty ;
+  rdfs:label "X3DGroupingNode field children is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DGroupingNode :X3DViewportNode :Anchor :Billboard :CADAssembly :CADLayer :Collision :EspduTransform :GeoLocation :GeoTransform :Group :HAnimSegment :HAnimSite :LOD :PickableGroup :ScreenGroup :Switch :Transform :Viewport ) ] ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:label "X3DGroupingNode field displayBBox is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DGroupingNode :X3DViewportNode :Anchor :Billboard :CADAssembly :CADLayer :CADPart :Collision :EspduTransform :GeoLocation :GeoTransform :Group :HAnimSegment :HAnimSite :LayoutGroup :LOD :PickableGroup :ScreenGroup :Switch :Transform :Viewport ) ] ;
+  rdfs:range :SFBool .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DGroupingNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DGroupingNode :X3DViewportNode :Anchor :Billboard :CADAssembly :CADLayer :CADPart :Collision :EspduTransform :GeoLocation :GeoTransform :Group :HAnimSegment :HAnimSite :LayoutGroup :LOD :PickableGroup :ScreenGroup :Switch :Transform :Viewport ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DInfoNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type for all nodes that contain only information without visual semantics." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DInterpolatorNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Interpolator nodes are designed for linear keyframed animation. Interpolators are driven by an input key ranging [0..1] and produce corresponding piecewise-linear output functions." .
+:key a owl:DatatypeProperty ;
+  rdfs:label "X3DInterpolatorNode field key is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DInterpolatorNode :ColorInterpolator :CoordinateInterpolator :CoordinateInterpolator2D :GeoPositionInterpolator :NormalInterpolator :OrientationInterpolator :PositionInterpolator :PositionInterpolator2D :ScalarInterpolator :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SquadOrientationInterpolator ) ] ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DKeyDeviceSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "Base type for all sensor node types that operate using key devices." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DLayerNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DPickableObject ;
+  rdfs:label "The X3DLayerNode abstract node type is the base node type for layer nodes." .
+:objectType a owl:DatatypeProperty ;
+  rdfs:label "X3DLayerNode field objectType is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLayerNode :Layer :LayoutLayer ) ] ;
+  rdfs:range :pickableObjectTypeValues .
+:pickable a owl:DatatypeProperty ;
+  rdfs:label "X3DLayerNode field pickable is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLayerNode :Layer :LayoutLayer ) ] ;
+  rdfs:range :SFBool .
+:viewport a owl:DatatypeProperty ;
+  rdfs:label "X3DLayerNode field viewport is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLayerNode :Layer :LayoutLayer ) ] ;
+  rdfs:range :X3DViewportNode ;
+  rdfs:subPropertyOf :hasChild .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DLayerNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLayerNode :Layer :LayoutLayer ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DLayoutNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "X3DLayoutNode is the base node type for layout nodes." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DLightNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Light nodes provide illumination for rendering geometry in the scene. Implementing nodes must include a global field with type SFBool and accessType inputOutput." .
+:ambientIntensity a owl:DatatypeProperty ;
+  rdfs:label "X3DLightNode field ambientIntensity is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLightNode :DirectionalLight :PointLight :SpotLight ) ] ;
+  rdfs:range :SFFloat .
+:color a owl:DatatypeProperty ;
+  rdfs:label "X3DLightNode field color is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLightNode :DirectionalLight :PointLight :SpotLight ) ] ;
+  rdfs:range :SFColor .
+:intensity a owl:DatatypeProperty ;
+  rdfs:label "X3DLightNode field intensity is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLightNode :DirectionalLight :PointLight :SpotLight ) ] ;
+  rdfs:range :SFFloat .
+:on a owl:DatatypeProperty ;
+  rdfs:label "X3DLightNode field on is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DLightNode :DirectionalLight :PointLight :SpotLight ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DMaterialNode a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "Base type for all Material nodes." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNBodyCollidableNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "The X3DNBodyCollidableNode abstract node type represents objects that act as the interface between the rigid body physics, collision geometry proxy, and renderable objects in the scene graph hierarchy." .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field bboxCenter is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field bboxSize is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFVec3f .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field displayBBox is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFBool .
+:enabled a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field enabled is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFBool .
+:rotation a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field rotation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFRotation .
+:translation a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field translation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFVec3f .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollidableNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollidableNode :CollidableOffset :CollidableShape ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNBodyCollisionSpaceNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "The X3DNBodyCollisionSpaceNode abstract node type represents objects that act as a self-contained spatial collection of objects that can interact through collision detection routines." .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollisionSpaceNode field bboxCenter is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollisionSpaceNode :CollisionSpace ) ] ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollisionSpaceNode field bboxSize is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollisionSpaceNode :CollisionSpace ) ] ;
+  rdfs:range :SFVec3f .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollisionSpaceNode field displayBBox is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollisionSpaceNode :CollisionSpace ) ] ;
+  rdfs:range :SFBool .
+:enabled a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollisionSpaceNode field enabled is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollisionSpaceNode :CollisionSpace ) ] ;
+  rdfs:range :SFBool .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DNBodyCollisionSpaceNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNBodyCollisionSpaceNode :CollisionSpace ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNetworkSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "Base typefor all sensors that generate events based on network activity." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNode a owl:Class ;
+  rdfs:label "All instantiable nodes implement X3DNode, which corresponds to SFNode in the X3D specification." .
+:DEF a owl:DatatypeProperty ;
+  rdfs:label "X3DNode field DEF is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNode :X3DProgrammableShaderObject :X3DAppearanceChildNode :X3DAppearanceNode :X3DBackgroundNode :X3DBindableNode :X3DChaserNode :X3DChildNode :X3DColorNode :X3DComposableVolumeRenderStyleNode :X3DComposedGeometryNode :X3DCoordinateNode :X3DDamperNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DEnvironmentTextureNode :X3DFollowerNode :X3DFontStyleNode :X3DGeometricPropertyNode :X3DGeometryNode :X3DGroupingNode :X3DInfoNode :X3DInterpolatorNode :X3DKeyDeviceSensorNode :X3DLayerNode :X3DLayoutNode :X3DLightNode :X3DMaterialNode :X3DNBodyCollidableNode :X3DNBodyCollisionSpaceNode :X3DNetworkSensorNode :X3DNormalNode :X3DNurbsControlCurveNode :X3DNurbsSurfaceGeometryNode :X3DParametricGeometryNode :X3DParticleEmitterNode :X3DParticlePhysicsModelNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DProductStructureChildNode :X3DRigidJointNode :X3DScriptNode :X3DSensorNode :X3DSequencerNode :X3DShaderNode :X3DShapeNode :X3DSoundNode :X3DSoundSourceNode :X3DTexture2DNode :X3DTexture3DNode :X3DTextureCoordinateNode :X3DTextureNode :X3DTextureTransformNode :X3DTimeDependentNode :X3DTouchSensorNode :X3DTriggerNode :X3DVertexAttributeNode :X3DViewpointNode :X3DViewportNode :X3DVolumeDataNode :X3DVolumeRenderStyleNode :Anchor :Appearance :Arc2D :ArcClose2D :AudioClip :Background :BallJoint :Billboard :BlendedVolumeStyle :BooleanFilter :BooleanSequencer :BooleanToggle :BooleanTrigger :BoundaryEnhancementVolumeStyle :BoundedPhysicsModel :Box :CADAssembly :CADFace :CADLayer :CADPart :CartoonVolumeStyle :Circle2D :ClipPlane :CollidableOffset :CollidableShape :Collision :CollisionCollection :CollisionSensor :CollisionSpace :Color :ColorChaser :ColorDamper :ColorInterpolator :ColorRGBA :ComposedCubeMapTexture :ComposedShader :ComposedTexture3D :ComposedVolumeStyle :Cone :ConeEmitter :Contact :Contour2D :ContourPolyline2D :Coordinate :CoordinateChaser :CoordinateDamper :CoordinateDouble :CoordinateInterpolator :CoordinateInterpolator2D :Cylinder :CylinderSensor :DirectionalLight :DISEntityManager :DISEntityTypeMapping :Disk2D :DoubleAxisHingeJoint :EaseInEaseOut :EdgeEnhancementVolumeStyle :ElevationGrid :EspduTransform :ExplosionEmitter :Extrusion :FillProperties :FloatVertexAttribute :Fog :FogCoordinate :FontStyle :ForcePhysicsModel :GeneratedCubeMapTexture :GeoCoordinate :GeoElevationGrid :GeoLocation :GeoLOD :GeoMetadata :GeoOrigin :GeoPositionInterpolator :GeoProximitySensor :GeoTouchSensor :GeoTransform :GeoViewpoint :Group :HAnimDisplacer :HAnimHumanoid :HAnimJoint :HAnimMotion :HAnimSegment :HAnimSite :ImageCubeMapTexture :ImageTexture :ImageTexture3D :IndexedFaceSet :IndexedLineSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :Inline :IntegerSequencer :IntegerTrigger :IsoSurfaceVolumeData :KeySensor :Layer :LayerSet :Layout :LayoutGroup :LayoutLayer :LinePickSensor :LineProperties :LineSet :LoadSensor :LocalFog :LOD :Material :Matrix3VertexAttribute :Matrix4VertexAttribute :MetadataBoolean :MetadataDouble :MetadataFloat :MetadataInteger :MetadataSet :MetadataString :MotorJoint :MovieTexture :MultiTexture :MultiTextureCoordinate :MultiTextureTransform :NavigationInfo :Normal :NormalInterpolator :NurbsCurve :NurbsCurve2D :NurbsOrientationInterpolator :NurbsPatchSurface :NurbsPositionInterpolator :NurbsSet :NurbsSurfaceInterpolator :NurbsSweptSurface :NurbsSwungSurface :NurbsTextureCoordinate :NurbsTrimmedSurface :OpacityMapVolumeStyle :OrientationChaser :OrientationDamper :OrientationInterpolator :OrthoViewpoint :PackagedShader :ParticleSystem :PickableGroup :PixelTexture :PixelTexture3D :PlaneSensor :PointEmitter :PointLight :PointPickSensor :PointProperties :PointSet :Polyline2D :PolylineEmitter :Polypoint2D :PositionChaser :PositionChaser2D :PositionDamper :PositionDamper2D :PositionInterpolator :PositionInterpolator2D :PrimitivePickSensor :ProgramShader :ProjectionVolumeStyle :ProtoInstance :ProximitySensor :QuadSet :ReceiverPdu :Rectangle2D :RigidBody :RigidBodyCollection :ScalarChaser :ScalarDamper :ScalarInterpolator :ScreenFontStyle :ScreenGroup :Script :SegmentedVolumeData :ShadedVolumeStyle :ShaderPart :ShaderProgram :Shape :SignalPdu :SilhouetteEnhancementVolumeStyle :SingleAxisHingeJoint :SliderJoint :Sound :Sphere :SphereSensor :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SpotLight :SquadOrientationInterpolator :StaticGroup :StringSensor :SurfaceEmitter :Switch :TexCoordChaser2D :TexCoordDamper2D :Text :TextureBackground :TextureCoordinate :TextureCoordinate3D :TextureCoordinate4D :TextureCoordinateGenerator :TextureProperties :TextureTransform :TextureTransform3D :TextureTransformMatrix3D :TimeSensor :TimeTrigger :ToneMappedVolumeStyle :TouchSensor :Transform :TransformSensor :TransmitterPdu :TriangleFanSet :TriangleSet :TriangleSet2D :TriangleStripSet :TwoSidedMaterial :UniversalJoint :Viewpoint :ViewpointGroup :Viewport :VisibilitySensor :VolumeData :VolumeEmitter :VolumePickSensor :WindPhysicsModel :WorldInfo ) ] ;
+  rdfs:range xs:ID .
+:USE a owl:DatatypeProperty ;
+  rdfs:label "X3DNode field USE is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNode :X3DProgrammableShaderObject :X3DAppearanceChildNode :X3DAppearanceNode :X3DBackgroundNode :X3DBindableNode :X3DChaserNode :X3DChildNode :X3DColorNode :X3DComposableVolumeRenderStyleNode :X3DComposedGeometryNode :X3DCoordinateNode :X3DDamperNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DEnvironmentTextureNode :X3DFollowerNode :X3DFontStyleNode :X3DGeometricPropertyNode :X3DGeometryNode :X3DGroupingNode :X3DInfoNode :X3DInterpolatorNode :X3DKeyDeviceSensorNode :X3DLayerNode :X3DLayoutNode :X3DLightNode :X3DMaterialNode :X3DNBodyCollidableNode :X3DNBodyCollisionSpaceNode :X3DNetworkSensorNode :X3DNormalNode :X3DNurbsControlCurveNode :X3DNurbsSurfaceGeometryNode :X3DParametricGeometryNode :X3DParticleEmitterNode :X3DParticlePhysicsModelNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DProductStructureChildNode :X3DRigidJointNode :X3DScriptNode :X3DSensorNode :X3DSequencerNode :X3DShaderNode :X3DShapeNode :X3DSoundNode :X3DSoundSourceNode :X3DTexture2DNode :X3DTexture3DNode :X3DTextureCoordinateNode :X3DTextureNode :X3DTextureTransformNode :X3DTimeDependentNode :X3DTouchSensorNode :X3DTriggerNode :X3DVertexAttributeNode :X3DViewpointNode :X3DViewportNode :X3DVolumeDataNode :X3DVolumeRenderStyleNode :Anchor :Appearance :Arc2D :ArcClose2D :AudioClip :Background :BallJoint :Billboard :BlendedVolumeStyle :BooleanFilter :BooleanSequencer :BooleanToggle :BooleanTrigger :BoundaryEnhancementVolumeStyle :BoundedPhysicsModel :Box :CADAssembly :CADFace :CADLayer :CADPart :CartoonVolumeStyle :Circle2D :ClipPlane :CollidableOffset :CollidableShape :Collision :CollisionCollection :CollisionSensor :CollisionSpace :Color :ColorChaser :ColorDamper :ColorInterpolator :ColorRGBA :ComposedCubeMapTexture :ComposedShader :ComposedTexture3D :ComposedVolumeStyle :Cone :ConeEmitter :Contact :Contour2D :ContourPolyline2D :Coordinate :CoordinateChaser :CoordinateDamper :CoordinateDouble :CoordinateInterpolator :CoordinateInterpolator2D :Cylinder :CylinderSensor :DirectionalLight :DISEntityManager :DISEntityTypeMapping :Disk2D :DoubleAxisHingeJoint :EaseInEaseOut :EdgeEnhancementVolumeStyle :ElevationGrid :EspduTransform :ExplosionEmitter :Extrusion :FillProperties :FloatVertexAttribute :Fog :FogCoordinate :FontStyle :ForcePhysicsModel :GeneratedCubeMapTexture :GeoCoordinate :GeoElevationGrid :GeoLocation :GeoLOD :GeoMetadata :GeoOrigin :GeoPositionInterpolator :GeoProximitySensor :GeoTouchSensor :GeoTransform :GeoViewpoint :Group :HAnimDisplacer :HAnimHumanoid :HAnimJoint :HAnimMotion :HAnimSegment :HAnimSite :ImageCubeMapTexture :ImageTexture :ImageTexture3D :IndexedFaceSet :IndexedLineSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :Inline :IntegerSequencer :IntegerTrigger :IsoSurfaceVolumeData :KeySensor :Layer :LayerSet :Layout :LayoutGroup :LayoutLayer :LinePickSensor :LineProperties :LineSet :LoadSensor :LocalFog :LOD :Material :Matrix3VertexAttribute :Matrix4VertexAttribute :MetadataBoolean :MetadataDouble :MetadataFloat :MetadataInteger :MetadataSet :MetadataString :MotorJoint :MovieTexture :MultiTexture :MultiTextureCoordinate :MultiTextureTransform :NavigationInfo :Normal :NormalInterpolator :NurbsCurve :NurbsCurve2D :NurbsOrientationInterpolator :NurbsPatchSurface :NurbsPositionInterpolator :NurbsSet :NurbsSurfaceInterpolator :NurbsSweptSurface :NurbsSwungSurface :NurbsTextureCoordinate :NurbsTrimmedSurface :OpacityMapVolumeStyle :OrientationChaser :OrientationDamper :OrientationInterpolator :OrthoViewpoint :PackagedShader :ParticleSystem :PickableGroup :PixelTexture :PixelTexture3D :PlaneSensor :PointEmitter :PointLight :PointPickSensor :PointProperties :PointSet :Polyline2D :PolylineEmitter :Polypoint2D :PositionChaser :PositionChaser2D :PositionDamper :PositionDamper2D :PositionInterpolator :PositionInterpolator2D :PrimitivePickSensor :ProgramShader :ProjectionVolumeStyle :ProtoInstance :ProximitySensor :QuadSet :ReceiverPdu :Rectangle2D :RigidBody :RigidBodyCollection :ScalarChaser :ScalarDamper :ScalarInterpolator :ScreenFontStyle :ScreenGroup :Script :SegmentedVolumeData :ShadedVolumeStyle :ShaderPart :ShaderProgram :Shape :SignalPdu :SilhouetteEnhancementVolumeStyle :SingleAxisHingeJoint :SliderJoint :Sound :Sphere :SphereSensor :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SpotLight :SquadOrientationInterpolator :StaticGroup :StringSensor :SurfaceEmitter :Switch :TexCoordChaser2D :TexCoordDamper2D :Text :TextureBackground :TextureCoordinate :TextureCoordinate3D :TextureCoordinate4D :TextureCoordinateGenerator :TextureProperties :TextureTransform :TextureTransform3D :TextureTransformMatrix3D :TimeSensor :TimeTrigger :ToneMappedVolumeStyle :TouchSensor :Transform :TransformSensor :TransmitterPdu :TriangleFanSet :TriangleSet :TriangleSet2D :TriangleStripSet :TwoSidedMaterial :UniversalJoint :Viewpoint :ViewpointGroup :Viewport :VisibilitySensor :VolumeData :VolumeEmitter :VolumePickSensor :WindPhysicsModel :WorldInfo ) ] ;
+  rdfs:range xs:IDREF .
+:class a owl:DatatypeProperty ;
+  rdfs:label "X3DNode field class is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNode :X3DProgrammableShaderObject :X3DAppearanceChildNode :X3DAppearanceNode :X3DBackgroundNode :X3DBindableNode :X3DChaserNode :X3DChildNode :X3DColorNode :X3DComposableVolumeRenderStyleNode :X3DComposedGeometryNode :X3DCoordinateNode :X3DDamperNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DEnvironmentTextureNode :X3DFollowerNode :X3DFontStyleNode :X3DGeometricPropertyNode :X3DGeometryNode :X3DGroupingNode :X3DInfoNode :X3DInterpolatorNode :X3DKeyDeviceSensorNode :X3DLayerNode :X3DLayoutNode :X3DLightNode :X3DMaterialNode :X3DNBodyCollidableNode :X3DNBodyCollisionSpaceNode :X3DNetworkSensorNode :X3DNormalNode :X3DNurbsControlCurveNode :X3DNurbsSurfaceGeometryNode :X3DParametricGeometryNode :X3DParticleEmitterNode :X3DParticlePhysicsModelNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DProductStructureChildNode :X3DRigidJointNode :X3DScriptNode :X3DSensorNode :X3DSequencerNode :X3DShaderNode :X3DShapeNode :X3DSoundNode :X3DSoundSourceNode :X3DTexture2DNode :X3DTexture3DNode :X3DTextureCoordinateNode :X3DTextureNode :X3DTextureTransformNode :X3DTimeDependentNode :X3DTouchSensorNode :X3DTriggerNode :X3DVertexAttributeNode :X3DViewpointNode :X3DViewportNode :X3DVolumeDataNode :X3DVolumeRenderStyleNode :Anchor :Appearance :Arc2D :ArcClose2D :AudioClip :Background :BallJoint :Billboard :BlendedVolumeStyle :BooleanFilter :BooleanSequencer :BooleanToggle :BooleanTrigger :BoundaryEnhancementVolumeStyle :BoundedPhysicsModel :Box :CADAssembly :CADFace :CADLayer :CADPart :CartoonVolumeStyle :Circle2D :ClipPlane :CollidableOffset :CollidableShape :Collision :CollisionCollection :CollisionSensor :CollisionSpace :Color :ColorChaser :ColorDamper :ColorInterpolator :ColorRGBA :ComposedCubeMapTexture :ComposedShader :ComposedTexture3D :ComposedVolumeStyle :Cone :ConeEmitter :Contact :Contour2D :ContourPolyline2D :Coordinate :CoordinateChaser :CoordinateDamper :CoordinateDouble :CoordinateInterpolator :CoordinateInterpolator2D :Cylinder :CylinderSensor :DirectionalLight :DISEntityManager :DISEntityTypeMapping :Disk2D :DoubleAxisHingeJoint :EaseInEaseOut :EdgeEnhancementVolumeStyle :ElevationGrid :EspduTransform :ExplosionEmitter :Extrusion :FillProperties :FloatVertexAttribute :Fog :FogCoordinate :FontStyle :ForcePhysicsModel :GeneratedCubeMapTexture :GeoCoordinate :GeoElevationGrid :GeoLocation :GeoLOD :GeoMetadata :GeoOrigin :GeoPositionInterpolator :GeoProximitySensor :GeoTouchSensor :GeoTransform :GeoViewpoint :Group :HAnimDisplacer :HAnimHumanoid :HAnimJoint :HAnimMotion :HAnimSegment :HAnimSite :ImageCubeMapTexture :ImageTexture :ImageTexture3D :IndexedFaceSet :IndexedLineSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :Inline :IntegerSequencer :IntegerTrigger :IsoSurfaceVolumeData :KeySensor :Layer :LayerSet :Layout :LayoutGroup :LayoutLayer :LinePickSensor :LineProperties :LineSet :LoadSensor :LocalFog :LOD :Material :Matrix3VertexAttribute :Matrix4VertexAttribute :MetadataBoolean :MetadataDouble :MetadataFloat :MetadataInteger :MetadataSet :MetadataString :MotorJoint :MovieTexture :MultiTexture :MultiTextureCoordinate :MultiTextureTransform :NavigationInfo :Normal :NormalInterpolator :NurbsCurve :NurbsCurve2D :NurbsOrientationInterpolator :NurbsPatchSurface :NurbsPositionInterpolator :NurbsSet :NurbsSurfaceInterpolator :NurbsSweptSurface :NurbsSwungSurface :NurbsTextureCoordinate :NurbsTrimmedSurface :OpacityMapVolumeStyle :OrientationChaser :OrientationDamper :OrientationInterpolator :OrthoViewpoint :PackagedShader :ParticleSystem :PickableGroup :PixelTexture :PixelTexture3D :PlaneSensor :PointEmitter :PointLight :PointPickSensor :PointProperties :PointSet :Polyline2D :PolylineEmitter :Polypoint2D :PositionChaser :PositionChaser2D :PositionDamper :PositionDamper2D :PositionInterpolator :PositionInterpolator2D :PrimitivePickSensor :ProgramShader :ProjectionVolumeStyle :ProtoInstance :ProximitySensor :QuadSet :ReceiverPdu :Rectangle2D :RigidBody :RigidBodyCollection :ScalarChaser :ScalarDamper :ScalarInterpolator :ScreenFontStyle :ScreenGroup :Script :SegmentedVolumeData :ShadedVolumeStyle :ShaderPart :ShaderProgram :Shape :SignalPdu :SilhouetteEnhancementVolumeStyle :SingleAxisHingeJoint :SliderJoint :Sound :Sphere :SphereSensor :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SpotLight :SquadOrientationInterpolator :StaticGroup :StringSensor :SurfaceEmitter :Switch :TexCoordChaser2D :TexCoordDamper2D :Text :TextureBackground :TextureCoordinate :TextureCoordinate3D :TextureCoordinate4D :TextureCoordinateGenerator :TextureProperties :TextureTransform :TextureTransform3D :TextureTransformMatrix3D :TimeSensor :TimeTrigger :ToneMappedVolumeStyle :TouchSensor :Transform :TransformSensor :TransmitterPdu :TriangleFanSet :TriangleSet :TriangleSet2D :TriangleStripSet :TwoSidedMaterial :UniversalJoint :Viewpoint :ViewpointGroup :Viewport :VisibilitySensor :VolumeData :VolumeEmitter :VolumePickSensor :WindPhysicsModel :WorldInfo ) ] ;
+  rdfs:range xs:NMTOKENS .
+:IS a owl:DatatypeProperty ;
+  rdfs:label "X3DNode field IS is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNode :X3DAppearanceChildNode :X3DAppearanceNode :X3DBackgroundNode :X3DBindableNode :X3DChaserNode :X3DChildNode :X3DColorNode :X3DComposableVolumeRenderStyleNode :X3DComposedGeometryNode :X3DCoordinateNode :X3DDamperNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DEnvironmentTextureNode :X3DFollowerNode :X3DFontStyleNode :X3DGeometricPropertyNode :X3DGeometryNode :X3DGroupingNode :X3DInfoNode :X3DInterpolatorNode :X3DKeyDeviceSensorNode :X3DLayerNode :X3DLayoutNode :X3DLightNode :X3DMaterialNode :X3DNBodyCollidableNode :X3DNBodyCollisionSpaceNode :X3DNetworkSensorNode :X3DNormalNode :X3DNurbsControlCurveNode :X3DNurbsSurfaceGeometryNode :X3DParametricGeometryNode :X3DParticleEmitterNode :X3DParticlePhysicsModelNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DProductStructureChildNode :X3DRigidJointNode :X3DSensorNode :X3DSequencerNode :X3DShaderNode :X3DShapeNode :X3DSoundNode :X3DSoundSourceNode :X3DTexture2DNode :X3DTexture3DNode :X3DTextureCoordinateNode :X3DTextureNode :X3DTextureTransformNode :X3DTimeDependentNode :X3DTouchSensorNode :X3DTriggerNode :X3DVertexAttributeNode :X3DViewpointNode :X3DViewportNode :X3DVolumeDataNode :X3DVolumeRenderStyleNode :Anchor :Appearance :Arc2D :ArcClose2D :AudioClip :Background :BallJoint :Billboard :BlendedVolumeStyle :BooleanFilter :BooleanSequencer :BooleanToggle :BooleanTrigger :BoundaryEnhancementVolumeStyle :BoundedPhysicsModel :Box :CADAssembly :CADFace :CADLayer :CADPart :CartoonVolumeStyle :Circle2D :ClipPlane :CollidableOffset :CollidableShape :Collision :CollisionCollection :CollisionSensor :CollisionSpace :Color :ColorChaser :ColorDamper :ColorInterpolator :ColorRGBA :ComposedCubeMapTexture :ComposedTexture3D :ComposedVolumeStyle :Cone :ConeEmitter :Contact :Contour2D :ContourPolyline2D :Coordinate :CoordinateChaser :CoordinateDamper :CoordinateDouble :CoordinateInterpolator :CoordinateInterpolator2D :Cylinder :CylinderSensor :DirectionalLight :DISEntityManager :DISEntityTypeMapping :Disk2D :DoubleAxisHingeJoint :EaseInEaseOut :EdgeEnhancementVolumeStyle :ElevationGrid :EspduTransform :ExplosionEmitter :Extrusion :FillProperties :FloatVertexAttribute :Fog :FogCoordinate :FontStyle :ForcePhysicsModel :GeneratedCubeMapTexture :GeoCoordinate :GeoElevationGrid :GeoLocation :GeoLOD :GeoMetadata :GeoOrigin :GeoPositionInterpolator :GeoProximitySensor :GeoTouchSensor :GeoTransform :GeoViewpoint :Group :HAnimDisplacer :HAnimHumanoid :HAnimJoint :HAnimMotion :HAnimSegment :HAnimSite :ImageCubeMapTexture :ImageTexture :ImageTexture3D :IndexedFaceSet :IndexedLineSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :Inline :IntegerSequencer :IntegerTrigger :IsoSurfaceVolumeData :KeySensor :Layer :LayerSet :Layout :LayoutGroup :LayoutLayer :LinePickSensor :LineProperties :LineSet :LoadSensor :LocalFog :LOD :Material :Matrix3VertexAttribute :Matrix4VertexAttribute :MetadataBoolean :MetadataDouble :MetadataFloat :MetadataInteger :MetadataString :MotorJoint :MovieTexture :MultiTexture :MultiTextureCoordinate :MultiTextureTransform :NavigationInfo :Normal :NormalInterpolator :NurbsCurve :NurbsCurve2D :NurbsOrientationInterpolator :NurbsPatchSurface :NurbsPositionInterpolator :NurbsSet :NurbsSurfaceInterpolator :NurbsSweptSurface :NurbsSwungSurface :NurbsTextureCoordinate :NurbsTrimmedSurface :OpacityMapVolumeStyle :OrientationChaser :OrientationDamper :OrientationInterpolator :OrthoViewpoint :ParticleSystem :PickableGroup :PixelTexture :PixelTexture3D :PlaneSensor :PointEmitter :PointLight :PointPickSensor :PointProperties :PointSet :Polyline2D :PolylineEmitter :Polypoint2D :PositionChaser :PositionChaser2D :PositionDamper :PositionDamper2D :PositionInterpolator :PositionInterpolator2D :PrimitivePickSensor :ProgramShader :ProjectionVolumeStyle :ProtoInstance :ProximitySensor :QuadSet :ReceiverPdu :Rectangle2D :RigidBody :RigidBodyCollection :ScalarChaser :ScalarDamper :ScalarInterpolator :ScreenFontStyle :ScreenGroup :Script :SegmentedVolumeData :ShadedVolumeStyle :ShaderPart :ShaderProgram :Shape :SignalPdu :SilhouetteEnhancementVolumeStyle :SingleAxisHingeJoint :SliderJoint :Sound :Sphere :SphereSensor :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SpotLight :SquadOrientationInterpolator :StaticGroup :StringSensor :SurfaceEmitter :Switch :TexCoordChaser2D :TexCoordDamper2D :Text :TextureBackground :TextureCoordinate :TextureCoordinate3D :TextureCoordinate4D :TextureCoordinateGenerator :TextureProperties :TextureTransform :TextureTransform3D :TextureTransformMatrix3D :TimeSensor :TimeTrigger :ToneMappedVolumeStyle :TouchSensor :Transform :TransformSensor :TransmitterPdu :TriangleFanSet :TriangleSet :TriangleSet2D :TriangleStripSet :TwoSidedMaterial :UniversalJoint :Viewpoint :ViewpointGroup :Viewport :VisibilitySensor :VolumeData :VolumeEmitter :VolumePickSensor :WindPhysicsModel :WorldInfo ) ] ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:metadata a owl:DatatypeProperty ;
+  rdfs:label "X3DNode field metadata is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNode :X3DAppearanceChildNode :X3DAppearanceNode :X3DBackgroundNode :X3DBindableNode :X3DChaserNode :X3DChildNode :X3DColorNode :X3DComposableVolumeRenderStyleNode :X3DComposedGeometryNode :X3DCoordinateNode :X3DDamperNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DEnvironmentTextureNode :X3DFollowerNode :X3DFontStyleNode :X3DGeometricPropertyNode :X3DGeometryNode :X3DGroupingNode :X3DInfoNode :X3DInterpolatorNode :X3DKeyDeviceSensorNode :X3DLayerNode :X3DLayoutNode :X3DLightNode :X3DMaterialNode :X3DNBodyCollidableNode :X3DNBodyCollisionSpaceNode :X3DNetworkSensorNode :X3DNormalNode :X3DNurbsControlCurveNode :X3DNurbsSurfaceGeometryNode :X3DParametricGeometryNode :X3DParticleEmitterNode :X3DParticlePhysicsModelNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DProductStructureChildNode :X3DRigidJointNode :X3DSensorNode :X3DSequencerNode :X3DShaderNode :X3DShapeNode :X3DSoundNode :X3DSoundSourceNode :X3DTexture2DNode :X3DTexture3DNode :X3DTextureCoordinateNode :X3DTextureNode :X3DTextureTransformNode :X3DTimeDependentNode :X3DTouchSensorNode :X3DTriggerNode :X3DVertexAttributeNode :X3DViewpointNode :X3DViewportNode :X3DVolumeDataNode :X3DVolumeRenderStyleNode :Anchor :Appearance :Arc2D :ArcClose2D :AudioClip :Background :BallJoint :Billboard :BlendedVolumeStyle :BooleanFilter :BooleanSequencer :BooleanToggle :BooleanTrigger :BoundaryEnhancementVolumeStyle :BoundedPhysicsModel :Box :CADAssembly :CADFace :CADLayer :CADPart :CartoonVolumeStyle :Circle2D :ClipPlane :CollidableOffset :CollidableShape :Collision :CollisionCollection :CollisionSensor :CollisionSpace :Color :ColorChaser :ColorDamper :ColorInterpolator :ColorRGBA :ComposedCubeMapTexture :ComposedTexture3D :ComposedVolumeStyle :Cone :ConeEmitter :Contact :Contour2D :ContourPolyline2D :Coordinate :CoordinateChaser :CoordinateDamper :CoordinateDouble :CoordinateInterpolator :CoordinateInterpolator2D :Cylinder :CylinderSensor :DirectionalLight :DISEntityManager :DISEntityTypeMapping :Disk2D :DoubleAxisHingeJoint :EaseInEaseOut :EdgeEnhancementVolumeStyle :ElevationGrid :EspduTransform :ExplosionEmitter :Extrusion :FillProperties :FloatVertexAttribute :Fog :FogCoordinate :FontStyle :ForcePhysicsModel :GeneratedCubeMapTexture :GeoCoordinate :GeoElevationGrid :GeoLocation :GeoLOD :GeoMetadata :GeoOrigin :GeoPositionInterpolator :GeoProximitySensor :GeoTouchSensor :GeoTransform :GeoViewpoint :Group :HAnimDisplacer :HAnimHumanoid :HAnimJoint :HAnimMotion :HAnimSegment :HAnimSite :ImageCubeMapTexture :ImageTexture :ImageTexture3D :IndexedFaceSet :IndexedLineSet :IndexedQuadSet :IndexedTriangleFanSet :IndexedTriangleSet :IndexedTriangleStripSet :Inline :IntegerSequencer :IntegerTrigger :IsoSurfaceVolumeData :KeySensor :Layer :LayerSet :Layout :LayoutGroup :LayoutLayer :LinePickSensor :LineProperties :LineSet :LoadSensor :LocalFog :LOD :Material :Matrix3VertexAttribute :Matrix4VertexAttribute :MetadataBoolean :MetadataDouble :MetadataFloat :MetadataInteger :MetadataString :MotorJoint :MovieTexture :MultiTexture :MultiTextureCoordinate :MultiTextureTransform :NavigationInfo :Normal :NormalInterpolator :NurbsCurve :NurbsCurve2D :NurbsOrientationInterpolator :NurbsPatchSurface :NurbsPositionInterpolator :NurbsSet :NurbsSurfaceInterpolator :NurbsSweptSurface :NurbsSwungSurface :NurbsTextureCoordinate :NurbsTrimmedSurface :OpacityMapVolumeStyle :OrientationChaser :OrientationDamper :OrientationInterpolator :OrthoViewpoint :ParticleSystem :PickableGroup :PixelTexture :PixelTexture3D :PlaneSensor :PointEmitter :PointLight :PointPickSensor :PointProperties :PointSet :Polyline2D :PolylineEmitter :Polypoint2D :PositionChaser :PositionChaser2D :PositionDamper :PositionDamper2D :PositionInterpolator :PositionInterpolator2D :PrimitivePickSensor :ProgramShader :ProjectionVolumeStyle :ProtoInstance :ProximitySensor :QuadSet :ReceiverPdu :Rectangle2D :RigidBody :RigidBodyCollection :ScalarChaser :ScalarDamper :ScalarInterpolator :ScreenFontStyle :ScreenGroup :Script :SegmentedVolumeData :ShadedVolumeStyle :ShaderPart :ShaderProgram :Shape :SignalPdu :SilhouetteEnhancementVolumeStyle :SingleAxisHingeJoint :SliderJoint :Sound :Sphere :SphereSensor :SplinePositionInterpolator :SplinePositionInterpolator2D :SplineScalarInterpolator :SpotLight :SquadOrientationInterpolator :StaticGroup :StringSensor :SurfaceEmitter :Switch :TexCoordChaser2D :TexCoordDamper2D :Text :TextureBackground :TextureCoordinate :TextureCoordinate3D :TextureCoordinate4D :TextureCoordinateGenerator :TextureProperties :TextureTransform :TextureTransform3D :TextureTransformMatrix3D :TimeSensor :TimeTrigger :ToneMappedVolumeStyle :TouchSensor :Transform :TransformSensor :TransmitterPdu :TriangleFanSet :TriangleSet :TriangleSet2D :TriangleStripSet :TwoSidedMaterial :UniversalJoint :Viewpoint :ViewpointGroup :Viewport :VisibilitySensor :VolumeData :VolumeEmitter :VolumePickSensor :WindPhysicsModel :WorldInfo ) ] ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+
+:X3DNormalNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "Base type for all normal node types in X3D." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNurbsControlCurveNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Base type for all nodes that provide control curve information in 2D space." .
+:controlPoint a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsControlCurveNode field controlPoint is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsControlCurveNode :ContourPolyline2D :NurbsCurve2D ) ] ;
+  rdfs:range :MFVec2d .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DNurbsSurfaceGeometryNode a owl:Class ;
+  rdfs:subClassOf :X3DParametricGeometryNode ;
+  rdfs:label "Abstract geometry type for all types of NURBS surfaces." .
+:controlPoint a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field controlPoint is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:solid a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field solid is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFBool .
+:texCoord a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field texCoord is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range  [ owl:unionOf ( :X3DTextureCoordinateNode :NurbsTextureCoordinate ) ] ;
+  rdfs:subPropertyOf :hasChild .
+:uClosed a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field uClosed is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFBool .
+:uDimension a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field uDimension is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:uKnot a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field uKnot is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :MFDouble .
+:uOrder a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field uOrder is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:uTessellation a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field uTessellation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:vClosed a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field vClosed is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFBool .
+:vDimension a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field vDimension is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:vKnot a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field vKnot is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :MFDouble .
+:vOrder a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field vOrder is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:vTessellation a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field vTessellation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:label "X3DNurbsSurfaceGeometryNode field weight is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DNurbsSurfaceGeometryNode :NurbsPatchSurface :NurbsTrimmedSurface ) ] ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DParametricGeometryNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Base type for all geometry node types that are created parametrically and use control points to describe the final shape of the surface." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DParticleEmitterNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "The X3DParticleEmitterNode abstract type represents any node that is an emitter of particles." .
+:mass a owl:DatatypeProperty ;
+  rdfs:label "X3DParticleEmitterNode field mass is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DParticleEmitterNode :ConeEmitter :ExplosionEmitter :PointEmitter :PolylineEmitter :SurfaceEmitter :VolumeEmitter ) ] ;
+  rdfs:range :SFFloat .
+:speed a owl:DatatypeProperty ;
+  rdfs:label "X3DParticleEmitterNode field speed is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DParticleEmitterNode :ConeEmitter :ExplosionEmitter :PointEmitter :PolylineEmitter :SurfaceEmitter :VolumeEmitter ) ] ;
+  rdfs:range :SFFloat .
+:surfaceArea a owl:DatatypeProperty ;
+  rdfs:label "X3DParticleEmitterNode field surfaceArea is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DParticleEmitterNode :ConeEmitter :ExplosionEmitter :PointEmitter :PolylineEmitter :SurfaceEmitter :VolumeEmitter ) ] ;
+  rdfs:range :SFFloat .
+:variation a owl:DatatypeProperty ;
+  rdfs:label "X3DParticleEmitterNode field variation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DParticleEmitterNode :ConeEmitter :ExplosionEmitter :PointEmitter :PolylineEmitter :SurfaceEmitter :VolumeEmitter ) ] ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DParticlePhysicsModelNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "The X3DParticlePhysicsModelNode abstract type represents any node that applies a form of constraints on the particles after they have been generated." .
+:enabled a owl:DatatypeProperty ;
+  rdfs:label "X3DParticlePhysicsModelNode field enabled is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DParticlePhysicsModelNode :BoundedPhysicsModel :ForcePhysicsModel :WindPhysicsModel ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DPickSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "The X3DPickSensorNode abstract node type is the base node type that represents the lowest common denominator of picking capabilities." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:intersectionType a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field intersectionType is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range :intersectionTypeValues .
+:matchCriterion a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field matchCriterion is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range :pickSensorMatchCriterionChoices .
+:objectType a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field objectType is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range :pickableObjectTypeValues .
+:pickingGeometry a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field pickingGeometry is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range :X3DGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:pickTarget a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field pickTarget is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range  [ owl:unionOf ( :X3DGroupingNode :X3DShapeNode :Inline ) ] ;
+  rdfs:subPropertyOf :hasChild .
+:sortOrder a owl:DatatypeProperty ;
+  rdfs:label "X3DPickSensorNode field sortOrder is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPickSensorNode :LinePickSensor :PointPickSensor :PrimitivePickSensor :VolumePickSensor ) ] ;
+  rdfs:range :pickSensorSortOrderValues .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DPointingDeviceSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "Base type for all pointing device sensors." .
+:description a owl:DatatypeProperty ;
+  rdfs:label "X3DPointingDeviceSensorNode field description is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPointingDeviceSensorNode :X3DDragSensorNode :X3DTouchSensorNode :CylinderSensor :GeoTouchSensor :PlaneSensor :SphereSensor :TouchSensor ) ] ;
+  rdfs:range :SFString .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DProductStructureChildNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type marking nodes that are valid product structure children for the CADGeometry component." .
+:name a owl:DatatypeProperty ;
+  rdfs:label "X3DProductStructureChildNode field name is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DProductStructureChildNode :CADAssembly :CADFace :CADPart ) ] ;
+  rdfs:range :SFString .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DPrototypeInstance a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Base type for all prototype instances. Note that direct children nodes are disallowed, instead let fieldValue with type SFNode/MFNode contain them. Current practice is that, if desired, prototype authors must explicitly add the metadata SFNode field in the ProtoInterface." .
+:IS a owl:DatatypeProperty ;
+  rdfs:label "X3DPrototypeInstance field IS is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPrototypeInstance ) ] ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:metadata a owl:DatatypeProperty ;
+  rdfs:label "X3DPrototypeInstance field metadata is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DPrototypeInstance ) ] ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+
+:X3DRigidJointNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "The X3DRigidJointNode abstract node type is the base type for all joint types." .
+:body1 a owl:DatatypeProperty ;
+  rdfs:label "X3DRigidJointNode field body1 is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DRigidJointNode :BallJoint :DoubleAxisHingeJoint :MotorJoint :SingleAxisHingeJoint :SliderJoint :UniversalJoint ) ] ;
+  rdfs:range :RigidBody ;
+  rdfs:subPropertyOf :hasChild .
+:body2 a owl:DatatypeProperty ;
+  rdfs:label "X3DRigidJointNode field body2 is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DRigidJointNode :BallJoint :DoubleAxisHingeJoint :MotorJoint :SingleAxisHingeJoint :SliderJoint :UniversalJoint ) ] ;
+  rdfs:range :RigidBody ;
+  rdfs:subPropertyOf :hasChild .
+:forceOutput a owl:DatatypeProperty ;
+  rdfs:label "X3DRigidJointNode field forceOutput is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DRigidJointNode :BallJoint :DoubleAxisHingeJoint :MotorJoint :SingleAxisHingeJoint :SliderJoint :UniversalJoint ) ] ;
+  rdfs:range :forceOutputValues .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DScriptNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "Base type for scripting nodes (but not shader nodes)." .
+:url a owl:DatatypeProperty ;
+  rdfs:label "X3DScriptNode field url is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DScriptNode :Script ) ] ;
+  rdfs:range :MFString .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+:IS a owl:DatatypeProperty ;
+  rdfs:label "X3DScriptNode field IS is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DScriptNode ) ] ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:metadata a owl:DatatypeProperty ;
+  rdfs:label "X3DScriptNode field metadata is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DScriptNode ) ] ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+
+:X3DSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type for all sensors." .
+:enabled a owl:DatatypeProperty ;
+  rdfs:label "X3DSensorNode field enabled is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DSensorNode :X3DDragSensorNode :X3DEnvironmentalSensorNode :X3DKeyDeviceSensorNode :X3DNetworkSensorNode :X3DPickSensorNode :X3DPointingDeviceSensorNode :X3DTouchSensorNode :Collision :CollisionSensor :CylinderSensor :GeoProximitySensor :GeoTouchSensor :KeySensor :LinePickSensor :LoadSensor :PlaneSensor :PointPickSensor :PrimitivePickSensor :ProximitySensor :ReceiverPdu :SignalPdu :SphereSensor :StringSensor :TimeSensor :TouchSensor :TransformSensor :TransmitterPdu :VisibilitySensor :VolumePickSensor ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DSequencerNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type from which all Sequencers are derived." .
+:key a owl:DatatypeProperty ;
+  rdfs:label "X3DSequencerNode field key is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DSequencerNode :BooleanSequencer :IntegerSequencer ) ] ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DShaderNode a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "Base type for all nodes that specify a programmable shader." .
+:language a owl:DatatypeProperty ;
+  rdfs:label "X3DShaderNode field language is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShaderNode :ComposedShader :PackagedShader :ProgramShader ) ] ;
+  rdfs:range :shaderLanguageValues .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DShapeNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "Base type for all Shape nodes." .
+:appearance a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field appearance is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :X3DAppearanceNode ;
+  rdfs:subPropertyOf :hasChild .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field bboxCenter is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field bboxSize is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :SFVec3f .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field displayBBox is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :SFBool .
+:geometry a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field geometry is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :X3DGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DShapeNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DShapeNode :ParticleSystem :Shape ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DSoundNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type for all sound nodes." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DSoundSourceNode a owl:Class ;
+  rdfs:subClassOf :X3DTimeDependentNode ;
+  rdfs:label "Nodes implementing X3DSoundSourceNode are allowed as children of Sound node." .
+:description a owl:DatatypeProperty ;
+  rdfs:label "X3DSoundSourceNode field description is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DSoundSourceNode :AudioClip :MovieTexture ) ] ;
+  rdfs:range :SFString .
+# loop field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFBool, default=false
+# pauseTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+:pitch a owl:DatatypeProperty ;
+  rdfs:label "X3DSoundSourceNode field pitch is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DSoundSourceNode :AudioClip :MovieTexture ) ] ;
+  rdfs:range :SFFloat .
+# resumeTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# startTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# stopTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTexture2DNode a owl:Class ;
+  rdfs:subClassOf :X3DTextureNode ;
+  rdfs:label "Base type for all nodes which specify 2D sources for texture images." .
+:repeatS a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture2DNode field repeatS is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture2DNode :ImageTexture :MovieTexture :PixelTexture ) ] ;
+  rdfs:range :SFBool .
+:repeatT a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture2DNode field repeatT is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture2DNode :ImageTexture :MovieTexture :PixelTexture ) ] ;
+  rdfs:range :SFBool .
+:textureProperties a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture2DNode field textureProperties is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture2DNode :ImageTexture :PixelTexture ) ] ;
+  rdfs:range :TextureProperties ;
+  rdfs:subPropertyOf :hasChild .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTexture3DNode a owl:Class ;
+  rdfs:subClassOf :X3DTextureNode ;
+  rdfs:label "Base type for all nodes that specify 3D sources for texture images." .
+:repeatR a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture3DNode field repeatR is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture3DNode :ComposedTexture3D :ImageTexture3D :PixelTexture3D ) ] ;
+  rdfs:range :SFBool .
+:repeatS a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture3DNode field repeatS is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture3DNode :ComposedTexture3D :ImageTexture3D :PixelTexture3D ) ] ;
+  rdfs:range :SFBool .
+:repeatT a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture3DNode field repeatT is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture3DNode :ComposedTexture3D :ImageTexture3D :PixelTexture3D ) ] ;
+  rdfs:range :SFBool .
+:textureProperties a owl:DatatypeProperty ;
+  rdfs:label "X3DTexture3DNode field textureProperties is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTexture3DNode :ComposedTexture3D :ImageTexture3D :PixelTexture3D ) ] ;
+  rdfs:range :TextureProperties ;
+  rdfs:subPropertyOf :hasChild .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTextureCoordinateNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "Base type for all nodes which specify texture coordinates." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTextureNode a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "Base type for all nodes which specify sources for texture images." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTextureTransformNode a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "Base type for all nodes which specify a transformation of texture coordinates." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTimeDependentNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type from which all time-dependent nodes are derived." .
+:loop a owl:DatatypeProperty ;
+  rdfs:label "X3DTimeDependentNode field loop is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTimeDependentNode :X3DSoundSourceNode :AudioClip :MovieTexture :TimeSensor ) ] ;
+  rdfs:range :SFBool .
+:pauseTime a owl:DatatypeProperty ;
+  rdfs:label "X3DTimeDependentNode field pauseTime is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTimeDependentNode :X3DSoundSourceNode :AudioClip :MovieTexture :TimeSensor ) ] ;
+  rdfs:range :SFTime .
+:resumeTime a owl:DatatypeProperty ;
+  rdfs:label "X3DTimeDependentNode field resumeTime is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTimeDependentNode :X3DSoundSourceNode :AudioClip :MovieTexture :TimeSensor ) ] ;
+  rdfs:range :SFTime .
+:startTime a owl:DatatypeProperty ;
+  rdfs:label "X3DTimeDependentNode field startTime is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTimeDependentNode :X3DSoundSourceNode :AudioClip :MovieTexture :TimeSensor ) ] ;
+  rdfs:range :SFTime .
+:stopTime a owl:DatatypeProperty ;
+  rdfs:label "X3DTimeDependentNode field stopTime is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DTimeDependentNode :X3DSoundSourceNode :AudioClip :MovieTexture :TimeSensor ) ] ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTouchSensorNode a owl:Class ;
+  rdfs:subClassOf :X3DPointingDeviceSensorNode ;
+  rdfs:label "Base type for all touch-style pointing device sensors." .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DTriggerNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "Base type from which all trigger nodes are derived." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DVertexAttributeNode a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "Base type for all nodes that specify per-vertex attribute information to the shader." .
+:name a owl:DatatypeProperty ;
+  rdfs:label "X3DVertexAttributeNode field name is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVertexAttributeNode :FloatVertexAttribute :Matrix3VertexAttribute :Matrix4VertexAttribute ) ] ;
+  rdfs:range xs:NMTOKEN .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DViewpointNode a owl:Class ;
+  rdfs:subClassOf :X3DBindableNode ;
+  rdfs:label "Node type X3DViewpointNode defines a specific location in the local coordinate system from which the user may view the scene, and also defines a viewpoint binding stack." .
+:description a owl:DatatypeProperty ;
+  rdfs:label "X3DViewpointNode field description is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DViewpointNode :GeoViewpoint :OrthoViewpoint :Viewpoint ) ] ;
+  rdfs:range :SFString .
+:jump a owl:DatatypeProperty ;
+  rdfs:label "X3DViewpointNode field jump is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DViewpointNode :GeoViewpoint :OrthoViewpoint :Viewpoint ) ] ;
+  rdfs:range :SFBool .
+:orientation a owl:DatatypeProperty ;
+  rdfs:label "X3DViewpointNode field orientation is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DViewpointNode :GeoViewpoint :OrthoViewpoint :Viewpoint ) ] ;
+  rdfs:range :SFRotation .
+:retainUserOffsets a owl:DatatypeProperty ;
+  rdfs:label "X3DViewpointNode field retainUserOffsets is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DViewpointNode :GeoViewpoint :OrthoViewpoint :Viewpoint ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DViewportNode a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "The X3DViewportNode abstract node type is the base node type for viewport nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DVolumeDataNode a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "The X3DVolumeDataNode abstract node type is the base type for all node types that describe volumetric data to be rendered." .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeDataNode field bboxCenter is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeDataNode :IsoSurfaceVolumeData :SegmentedVolumeData :VolumeData ) ] ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeDataNode field bboxSize is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeDataNode :IsoSurfaceVolumeData :SegmentedVolumeData :VolumeData ) ] ;
+  rdfs:range :SFVec3f .
+:dimensions a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeDataNode field dimensions is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeDataNode :IsoSurfaceVolumeData :SegmentedVolumeData :VolumeData ) ] ;
+  rdfs:range :SFVec3f .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeDataNode field displayBBox is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeDataNode :IsoSurfaceVolumeData :SegmentedVolumeData :VolumeData ) ] ;
+  rdfs:range :SFBool .
+:visible a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeDataNode field visible is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeDataNode :IsoSurfaceVolumeData :SegmentedVolumeData :VolumeData ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:X3DVolumeRenderStyleNode a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "The X3DVolumeRenderStyleNode abstract node type is the base type for all node types that specify a specific visual rendering style to be used when rendering volume data." .
+:enabled a owl:DatatypeProperty ;
+  rdfs:label "X3DVolumeRenderStyleNode field enabled is implemented by multiple nodes" ;
+  rdfs:domain [ owl:unionOf (  :X3DVolumeRenderStyleNode :X3DComposableVolumeRenderStyleNode :BlendedVolumeStyle :BoundaryEnhancementVolumeStyle :CartoonVolumeStyle :ComposedVolumeStyle :EdgeEnhancementVolumeStyle :OpacityMapVolumeStyle :ProjectionVolumeStyle :ShadedVolumeStyle :SilhouetteEnhancementVolumeStyle :ToneMappedVolumeStyle ) ] ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+###############################################
+
+# AbstractObjectTypes
+
+:X3DBoundedObject a owl:Class ;
+  rdfs:label "X3DBoundedObject indicates that bounding box values can be provided (or computed) to encompass this node and any children." .
+:bboxCenter a owl:DatatypeProperty ;
+  rdfs:domain :X3DBoundedObject ;
+  rdfs:range :SFVec3f .
+:bboxSize a owl:DatatypeProperty ;
+  rdfs:domain :X3DBoundedObject ;
+  rdfs:range :bboxSizeType .
+:displayBBox a owl:DatatypeProperty ;
+  rdfs:domain :X3DBoundedObject ;
+  rdfs:range :SFBool .
+:visible a owl:DatatypeProperty ;
+  rdfs:domain :X3DBoundedObject ;
+  rdfs:range :SFBool .
+
+:X3DFogObject a owl:Class ;
+  rdfs:label "Abstract type describing a node that influences the lighting equation through the use of fog semantics." .
+:color a owl:DatatypeProperty ;
+  rdfs:domain :X3DFogObject ;
+  rdfs:range :SFColor .
+:fogType a owl:DatatypeProperty ;
+  rdfs:domain :X3DFogObject ;
+  rdfs:range :fogTypeChoices .
+:visibilityRange a owl:DatatypeProperty ;
+  rdfs:domain :X3DFogObject ;
+  rdfs:range :SFFloat .
+
+:X3DMetadataObject a owl:Class ;
+  rdfs:label "Each node inheriting the X3DMetadataObject interface contains a single array of strictly typed values: MFBool, MFInt32, MFFloat, MFDouble, MFString, or MFNode, the latter having children that are all Metadata nodes." .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :X3DMetadataObject ;
+  rdfs:range :SFString .
+:reference a owl:DatatypeProperty ;
+  rdfs:domain :X3DMetadataObject ;
+  rdfs:range :SFString .
+
+:X3DPickableObject a owl:Class ;
+  rdfs:label "The X3DPickableObject abstract interface marks a node as being capable of having customized picking performed on its contents or children." .
+:pickable a owl:DatatypeProperty ;
+  rdfs:domain :X3DPickableObject ;
+  rdfs:range :SFBool .
+
+:X3DProgrammableShaderObject a owl:Class ;
+  rdfs:label "Base type for all nodes that specify arbitrary fields for interfacing with per-object attribute values." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+
+:X3DUrlObject a owl:Class ;
+  rdfs:label "X3DUrlObject indicates that a node has content loaded from a Uniform Resource Locator (URL) and can be tracked via a LoadSensor. Such child nodes have containerField='watchList' to indicate their relationship to the parent LoadSensor node." .
+:url a owl:DatatypeProperty ;
+  rdfs:domain :X3DUrlObject ;
+  rdfs:range :MFString .
+
+###############################################
+
+# Statements
+
+:component a owl:Class ;
+  rdfs:label "Functional summary: each added component statement indicates needed scene functionality support above the given X3D profile." .
+:level a owl:DatatypeProperty ;
+  rdfs:domain :component ;
+  rdfs:range :SFInt32 .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :component ;
+  rdfs:range :componentNameChoices .
+
+:connect a owl:Class ;
+  rdfs:label "Functional summary: connect statements define event-routing connections between node fields defined inside a ProtoBody declaration back to corresponding ProtoInterface fields." .
+:nodeField a owl:DatatypeProperty ;
+  rdfs:domain :connect ;
+  rdfs:range xs:NMTOKEN .
+:protoField a owl:DatatypeProperty ;
+  rdfs:domain :connect ;
+  rdfs:range xs:NMTOKEN .
+
+:EXPORT a owl:Class ;
+  rdfs:label "Functional summary: EXPORT exposes a local node for ROUTE passing of event values when the current Scene is included via Inline by a parent external world. These connections allow event values to be exchanged via ROUTE statements between a parent model and a child Inline model." .
+:AS a owl:DatatypeProperty ;
+  rdfs:domain :EXPORT ;
+  rdfs:range xs:NMTOKEN .
+:localDEF a owl:DatatypeProperty ;
+  rdfs:domain :EXPORT ;
+  rdfs:range xs:IDREF .
+
+:ExternProtoDeclare a owl:Class ;
+  rdfs:label "ExternProtoDeclare refers to a ProtoDeclare node declaration provided in another file. ExternProtoDeclare interfaces are defined by field statements (and without IS/connect statements)." .
+:appinfo a owl:DatatypeProperty ;
+  rdfs:domain :ExternProtoDeclare ;
+  rdfs:range :SFString .
+:documentation a owl:DatatypeProperty ;
+  rdfs:domain :ExternProtoDeclare ;
+  rdfs:range :SFString .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :ExternProtoDeclare ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentExternProtoDeclare a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentExternProtoDeclare .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :ExternProtoDeclare ;
+  rdfs:range xs:NMTOKEN .
+:url a owl:DatatypeProperty ;
+  rdfs:domain :ExternProtoDeclare ;
+  rdfs:range :MFString .
+
+:field a owl:Class ;
+  rdfs:label "Functional summary: a field statement defines an interface attribute or node. Each field statement can contain either attribute-value or node content." .
+:accessType a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range :accessTypeChoices .
+:appinfo a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range :SFString .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :field ;
+  rdfs:range :X3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentfield .
+:documentation a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range :SFString .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range xs:NMTOKEN .
+:type a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range :fieldTypeChoices .
+:value a owl:DatatypeProperty ;
+  rdfs:domain :field ;
+  rdfs:range :SFString .
+
+:fieldValue a owl:Class ;
+  rdfs:label "Functional summary: a fieldValue statement re-initializes the default value of a field in a ProtoInstance. Each fieldValue statement can contain either attribute-value or node content." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :fieldValue ;
+  rdfs:range :X3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentfieldValue .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :fieldValue ;
+  rdfs:range xs:NMTOKEN .
+:value a owl:DatatypeProperty ;
+  rdfs:domain :fieldValue ;
+  rdfs:range :SFString .
+
+:head a owl:Class ;
+  rdfs:label "Functional summary: each X3D scene includes a head statement that can contain component, unit and meta statements." .
+:hasComponent a owl:ObjectProperty ;
+  rdfs:domain :head ;
+  rdfs:range :component ;
+  rdfs:subPropertyOf :hasChild .
+:fieldComponentHasParenthead a owl:ObjectProperty ;
+  owl:inverseOf :hasComponent ;
+  rdfs:subPropertyOf :hasParenthead .
+:hasMeta a owl:ObjectProperty ;
+  rdfs:domain :head ;
+  rdfs:range :meta ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMetaHasParenthead a owl:ObjectProperty ;
+  owl:inverseOf :hasMeta ;
+  rdfs:subPropertyOf :hasParenthead .
+:hasUnit a owl:ObjectProperty ;
+  rdfs:domain :head ;
+  rdfs:range :unit ;
+  rdfs:subPropertyOf :hasChild .
+:fieldUnitHasParenthead a owl:ObjectProperty ;
+  owl:inverseOf :hasUnit ;
+  rdfs:subPropertyOf :hasParenthead .
+
+:IMPORT a owl:Class ;
+  rdfs:label "Functional summary: IMPORT provides ROUTE access to a node that has a corresponding EXPORT statement within an Inline scene. These connections allow event values to be exchanged via ROUTE statements between a parent model and a child Inline model." .
+:AS a owl:DatatypeProperty ;
+  rdfs:domain :IMPORT ;
+  rdfs:range xs:ID .
+:importedDEF a owl:DatatypeProperty ;
+  rdfs:domain :IMPORT ;
+  rdfs:range xs:NMTOKEN .
+:inlineDEF a owl:DatatypeProperty ;
+  rdfs:domain :IMPORT ;
+  rdfs:range xs:IDREF .
+
+:IS a owl:Class ;
+  rdfs:label "Functional summary: the IS statement connects node fields defined inside a ProtoBody declaration back to corresponding ProtoInterface fields. IS/connect statements can be added if the parent node is within a ProtoBody and connect statements define correspondences between prototype fields and built-in node fields." .
+:hasConnect a owl:ObjectProperty ;
+  rdfs:domain :IS ;
+  rdfs:range :connect ;
+  rdfs:subPropertyOf :hasChild .
+:fieldConnectHasParentIS a owl:ObjectProperty ;
+  owl:inverseOf :hasConnect ;
+  rdfs:subPropertyOf :hasParentIS .
+
+:meta a owl:Class ;
+  rdfs:label "Functional summary: the meta statement provides metadata information about a scene, where name and content attributes provide attribute=value metadata pairs." .
+:content a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :SFString .
+:dir a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :metaDirectionChoices .
+:http-equiv a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :SFString .
+:lang a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :SFString .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :metaNameValues .
+:scheme a owl:DatatypeProperty ;
+  rdfs:domain :meta ;
+  rdfs:range :SFString .
+
+:ProtoBody a owl:Class ;
+  rdfs:label "ProtoBody contains the definition nodes for new Prototype nodes." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :ProtoBody ;
+  rdfs:range :X3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentProtoBody .
+
+:ProtoDeclare a owl:Class ;
+  rdfs:label "ProtoDeclare defines new Prototype nodes. Nested ProtoDeclares and ProtoInstances are allowed by the specification." .
+:appinfo a owl:DatatypeProperty ;
+  rdfs:domain :ProtoDeclare ;
+  rdfs:range :SFString .
+:documentation a owl:DatatypeProperty ;
+  rdfs:domain :ProtoDeclare ;
+  rdfs:range :SFString .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :ProtoDeclare ;
+  rdfs:range xs:NMTOKEN .
+:hasProtoBody a owl:ObjectProperty ;
+  rdfs:domain :ProtoDeclare ;
+  rdfs:range :ProtoBody ;
+  rdfs:subPropertyOf :hasChild .
+:fieldProtoBodyHasParentProtoDeclare a owl:ObjectProperty ;
+  owl:inverseOf :hasProtoBody ;
+  rdfs:subPropertyOf :hasParentProtoDeclare .
+:hasProtoInterface a owl:ObjectProperty ;
+  rdfs:domain :ProtoDeclare ;
+  rdfs:range :ProtoInterface ;
+  rdfs:subPropertyOf :hasChild .
+:fieldProtoInterfaceHasParentProtoDeclare a owl:ObjectProperty ;
+  owl:inverseOf :hasProtoInterface ;
+  rdfs:subPropertyOf :hasParentProtoDeclare .
+
+:ProtoInterface a owl:Class ;
+  rdfs:label "ProtoInterface defines fields for new Prototype nodes." .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :ProtoInterface ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentProtoInterface a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentProtoInterface .
+
+:ROUTE a owl:Class ;
+  rdfs:label "ROUTE connects output fields of event-producing nodes to input fields of event-consuming nodes." .
+:fromField a owl:DatatypeProperty ;
+  rdfs:domain :ROUTE ;
+  rdfs:range xs:NMTOKEN .
+:fromNode a owl:DatatypeProperty ;
+  rdfs:domain :ROUTE ;
+  rdfs:range xs:IDREF .
+:toField a owl:DatatypeProperty ;
+  rdfs:domain :ROUTE ;
+  rdfs:range xs:NMTOKEN .
+:toNode a owl:DatatypeProperty ;
+  rdfs:domain :ROUTE ;
+  rdfs:range xs:IDREF .
+
+:Scene a owl:Class ;
+  rdfs:label "Scene is the implicit root node of the X3D scene graph." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :Scene ;
+  rdfs:range  [ owl:unionOf (:X3DChildNode :X3DMetadataObject :LayerSet) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentScene .
+
+:unit a owl:Class ;
+  rdfs:label "Functional summary: unit statement defines data-conversion factors for typed values defined in a scene." .
+:category a owl:DatatypeProperty ;
+  rdfs:domain :unit ;
+  rdfs:range :unitCategoryChoices .
+:conversionFactor a owl:DatatypeProperty ;
+  rdfs:domain :unit ;
+  rdfs:range :SFDouble .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :unit ;
+  rdfs:range xs:NMTOKEN .
+
+:X3D a owl:Class ;
+  rdfs:label "X3D is the root node for an Extensible 3D (X3D) Graphics model." .
+:hasHead a owl:ObjectProperty ;
+  rdfs:domain :X3D ;
+  rdfs:range :head ;
+  rdfs:subPropertyOf :hasChild .
+:fieldHeadHasParentX3D a owl:ObjectProperty ;
+  owl:inverseOf :hasHead ;
+  rdfs:subPropertyOf :hasParentX3D .
+:profile a owl:DatatypeProperty ;
+  rdfs:domain :X3D ;
+  rdfs:range :profileNameChoices .
+:hasScene a owl:ObjectProperty ;
+  rdfs:domain :X3D ;
+  rdfs:range :Scene ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSceneHasParentX3D a owl:ObjectProperty ;
+  owl:inverseOf :hasScene ;
+  rdfs:subPropertyOf :hasParentX3D .
+:version a owl:DatatypeProperty ;
+  rdfs:domain :X3D ;
+  rdfs:range :x3dVersionChoices .
+
+###############################################
+
+# ConcreteNodes
+
+:Anchor a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "Anchor is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+:description a owl:DatatypeProperty ;
+  rdfs:domain :Anchor ;
+  rdfs:range :SFString .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:parameter a owl:DatatypeProperty ;
+  rdfs:domain :Anchor ;
+  rdfs:range :MFString .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Appearance a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceNode ;
+  rdfs:label "Appearance specifies the visual properties of geometry by containing the Material, ImageTexture/MovieTexture/PixelTexture, FillProperties, LineProperties, programmable shader nodes (ComposedShader, PackagedShader, ProgramShader) and TextureTransform nodes." .
+:hasFillProperties a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :FillProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFillPropertiesHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasFillProperties ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasLineProperties a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :LineProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLinePropertiesHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasLineProperties ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasMaterial a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :X3DMaterialNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMaterialHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasMaterial ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasPointProperties a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :PointProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldPointPropertiesHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasPointProperties ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasShaders a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :X3DShaderNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldShadersHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasShaders ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasTexture a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :X3DTextureNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTextureHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasTexture ;
+  rdfs:subPropertyOf :hasParentAppearance .
+:hasTextureTransform a owl:ObjectProperty ;
+  rdfs:domain :Appearance ;
+  rdfs:range :X3DTextureTransformNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTextureTransformHasParentAppearance a owl:ObjectProperty ;
+  owl:inverseOf :hasTextureTransform ;
+  rdfs:subPropertyOf :hasParentAppearance .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Arc2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Arc2D is a line-based geometry node that defines a linear circular arc with center (0,0) in X-Y plane, with angles measured starting at positive x-axis and sweeping towards positive y-axis." .
+:endAngle a owl:DatatypeProperty ;
+  rdfs:domain :Arc2D ;
+  rdfs:range :SFFloat .
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :Arc2D ;
+  rdfs:range :SFFloat .
+:startAngle a owl:DatatypeProperty ;
+  rdfs:domain :Arc2D ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ArcClose2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "ArcClose2D is a polygonal geometry node that defines a linear circular arc, closed by PIE or CHORD line segments, with center (0,0) in X-Y plane, with angles measured starting at positive x-axis and sweeping towards positive y-axis." .
+:closureType a owl:DatatypeProperty ;
+  rdfs:domain :ArcClose2D ;
+  rdfs:range :closureTypeChoices .
+:endAngle a owl:DatatypeProperty ;
+  rdfs:domain :ArcClose2D ;
+  rdfs:range :SFFloat .
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :ArcClose2D ;
+  rdfs:range :SFFloat .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :ArcClose2D ;
+  rdfs:range :SFBool .
+:startAngle a owl:DatatypeProperty ;
+  rdfs:domain :ArcClose2D ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:AudioClip a owl:Class ;
+  rdfs:subClassOf :X3DSoundSourceNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "AudioClip provides audio data used by parent Sound nodes." .
+# description field inheritedFrom=X3DSoundSourceNode with accessType=inputOutput, type=SFString
+# loop field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFBool, default=false
+# pauseTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# pitch field inheritedFrom=X3DSoundSourceNode with accessType=inputOutput, type=SFFloat, default=1.0
+# resumeTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# startTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# stopTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Background a owl:Class ;
+  rdfs:subClassOf :X3DBackgroundNode ;
+  rdfs:label "Background simulates ground and sky, using vertical arrays of wraparound color values." .
+:backUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+:bottomUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+:frontUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+# groundAngle field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFFloat
+# groundColor field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFColor
+:leftUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+:rightUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+# skyAngle field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFFloat
+# skyColor field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFColor, default=0 0 0
+:topUrl a owl:DatatypeProperty ;
+  rdfs:domain :Background ;
+  rdfs:range :MFString .
+# transparency field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=SFFloat, default=0, baseType=intensityType
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BallJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "BallJoint represents an unconstrained joint between two bodies that pivot about a common anchor point." .
+:anchorPoint a owl:DatatypeProperty ;
+  rdfs:domain :BallJoint ;
+  rdfs:range :SFVec3f .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Billboard a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "Billboard is a Grouping node that can contain most nodes." .
+:axisOfRotation a owl:DatatypeProperty ;
+  rdfs:domain :Billboard ;
+  rdfs:range :SFVec3f .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BlendedVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "BlendedVolumeStyle combines rendering of two voxel data sets into one by blending voxel values." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:hasRenderStyle a owl:ObjectProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :X3DComposableVolumeRenderStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRenderStyleHasParentBlendedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasRenderStyle ;
+  rdfs:subPropertyOf :hasParentBlendedVolumeStyle .
+:hasVoxels a owl:ObjectProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldVoxelsHasParentBlendedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasVoxels ;
+  rdfs:subPropertyOf :hasParentBlendedVolumeStyle .
+:weightConstant1 a owl:DatatypeProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :SFFloat .
+:weightConstant2 a owl:DatatypeProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :SFFloat .
+:weightFunction1 a owl:DatatypeProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :volumeRenderingWeightFunctionChoices .
+:weightFunction2 a owl:DatatypeProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :volumeRenderingWeightFunctionChoices .
+:hasWeightTransferFunction1 a owl:ObjectProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldWeightTransferFunction1HasParentBlendedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasWeightTransferFunction1 ;
+  rdfs:subPropertyOf :hasParentBlendedVolumeStyle .
+:hasWeightTransferFunction2 a owl:ObjectProperty ;
+  rdfs:domain :BlendedVolumeStyle ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldWeightTransferFunction2HasParentBlendedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasWeightTransferFunction2 ;
+  rdfs:subPropertyOf :hasParentBlendedVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BooleanFilter a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "BooleanFilter selectively passes true, false or negated events." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BooleanSequencer a owl:Class ;
+  rdfs:subClassOf :X3DSequencerNode ;
+  rdfs:label "BooleanSequencer generates periodic discrete Boolean values." .
+# key field inheritedFrom=X3DSequencerNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :BooleanSequencer ;
+  rdfs:range :MFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BooleanToggle a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "BooleanToggle maintains state and negates output when a true input is provided." .
+:toggle a owl:DatatypeProperty ;
+  rdfs:domain :BooleanToggle ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BooleanTrigger a owl:Class ;
+  rdfs:subClassOf :X3DTriggerNode ;
+  rdfs:label "BooleanTrigger converts time events to boolean true events." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BoundaryEnhancementVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "BoundaryEnhancementVolumeStyle provides boundary enhancement for the volume rendering style." .
+:boundaryOpacity a owl:DatatypeProperty ;
+  rdfs:domain :BoundaryEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:opacityFactor a owl:DatatypeProperty ;
+  rdfs:domain :BoundaryEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+:retainedOpacity a owl:DatatypeProperty ;
+  rdfs:domain :BoundaryEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:BoundedPhysicsModel a owl:Class ;
+  rdfs:subClassOf :X3DParticlePhysicsModelNode ;
+  rdfs:label "BoundedPhysicsModel provides user-defined geometrical boundaries for particle motion." .
+# enabled field inheritedFrom=X3DParticlePhysicsModelNode with accessType=inputOutput, type=SFBool, default=true
+:hasGeometry a owl:ObjectProperty ;
+  rdfs:domain :BoundedPhysicsModel ;
+  rdfs:range :X3DGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometryHasParentBoundedPhysicsModel a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry ;
+  rdfs:subPropertyOf :hasParentBoundedPhysicsModel .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Box a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Box is a geometry node specifying a rectangular cuboid." .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :Box ;
+  rdfs:range :SFVec3f .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Box ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CADAssembly a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:subClassOf :X3DProductStructureChildNode ;
+  rdfs:label "CADAssembly holds a set of Computer-Aided Design (CAD) assemblies or parts grouped together." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# name field inheritedFrom=X3DProductStructureChildNode with accessType=inputOutput, type=SFString
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CADFace a owl:Class ;
+  rdfs:subClassOf :X3DProductStructureChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "CADFace holds geometry representing one face in a Computer-Aided Design (CAD) CADPart." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+# name field inheritedFrom=X3DProductStructureChildNode with accessType=inputOutput, type=SFString
+:hasShape a owl:ObjectProperty ;
+  rdfs:domain :CADFace ;
+  rdfs:range  [ owl:unionOf (:Shape :LOD :Transform) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldShapeHasParentCADFace a owl:ObjectProperty ;
+  owl:inverseOf :hasShape ;
+  rdfs:subPropertyOf :hasParentCADFace .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CADLayer a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "CADLayer nodes define a hierarchy that shows layer structure for a Computer-Aided Design (CAD) model." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:name a owl:DatatypeProperty ;
+  rdfs:domain :CADLayer ;
+  rdfs:range :SFString .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CADPart a owl:Class ;
+  rdfs:subClassOf :X3DProductStructureChildNode ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "CADPart is an atomic part that defines both coordinate-system location and the faces that constitute a part in a Computer-Aided Design (CAD) model." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :SFVec3f .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :CADFace ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentCADPart .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# name field inheritedFrom=X3DProductStructureChildNode with accessType=inputOutput, type=SFString
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :SFRotation .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :CADPart ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CartoonVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "CartoonVolumeStyle generates cartoon-style non-photorealistic rendering of associated volumetric data." .
+:colorSteps a owl:DatatypeProperty ;
+  rdfs:domain :CartoonVolumeStyle ;
+  rdfs:range :SFInt32 .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:orthogonalColor a owl:DatatypeProperty ;
+  rdfs:domain :CartoonVolumeStyle ;
+  rdfs:range :SFColorRGBA .
+:parallelColor a owl:DatatypeProperty ;
+  rdfs:domain :CartoonVolumeStyle ;
+  rdfs:range :SFColorRGBA .
+:hasSurfaceNormals a owl:ObjectProperty ;
+  rdfs:domain :CartoonVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceNormalsHasParentCartoonVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasSurfaceNormals ;
+  rdfs:subPropertyOf :hasParentCartoonVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Circle2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Circle2D is a geometry node that defines a linear X-Y circle with center (0,0) in X-Y plane." .
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :Circle2D ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ClipPlane a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "ClipPlane specifies a single plane equation used to clip (i." .
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :ClipPlane ;
+  rdfs:range :SFBool .
+:plane a owl:DatatypeProperty ;
+  rdfs:domain :ClipPlane ;
+  rdfs:range :SFVec4f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CollidableOffset a owl:Class ;
+  rdfs:subClassOf :X3DNBodyCollidableNode ;
+  rdfs:label "CollidableOffset repositions geometry relative to center of owning body." .
+# bboxCenter field inheritedFrom=X3DNBodyCollidableNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DNBodyCollidableNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:hasCollidable a owl:ObjectProperty ;
+  rdfs:domain :CollidableOffset ;
+  rdfs:range :X3DNBodyCollidableNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCollidableHasParentCollidableOffset a owl:ObjectProperty ;
+  owl:inverseOf :hasCollidable ;
+  rdfs:subPropertyOf :hasParentCollidableOffset .
+# displayBBox field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=true
+# rotation field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFRotation, default=0 0 1 0
+# translation field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFVec3f, default=0 0 0
+# visible field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CollidableShape a owl:Class ;
+  rdfs:subClassOf :X3DNBodyCollidableNode ;
+  rdfs:label "CollidableShape connects the collision detection system, the rigid body model, and the renderable scene graph." .
+# bboxCenter field inheritedFrom=X3DNBodyCollidableNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DNBodyCollidableNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=true
+# rotation field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFRotation, default=0 0 1 0
+:hasShape a owl:ObjectProperty ;
+  rdfs:domain :CollidableShape ;
+  rdfs:range :Shape ;
+  rdfs:subPropertyOf :hasChild .
+:fieldShapeHasParentCollidableShape a owl:ObjectProperty ;
+  owl:inverseOf :hasShape ;
+  rdfs:subPropertyOf :hasParentCollidableShape .
+# translation field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFVec3f, default=0 0 0
+# visible field inheritedFrom=X3DNBodyCollidableNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Collision a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "Collision detects camera-to-object contact using current view and NavigationInfo avatarSize." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:hasProxy a owl:ObjectProperty ;
+  rdfs:domain :Collision ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldProxyHasParentCollision a owl:ObjectProperty ;
+  owl:inverseOf :hasProxy ;
+  rdfs:subPropertyOf :hasParentCollision .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CollisionCollection a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "CollisionCollection holds a collection of objects that can be managed as a single entity for resolution of inter-object collisions." .
+:appliedParameters a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :appliedParametersChoices .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:bounce a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFFloat .
+:hasCollidables a owl:ObjectProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range  [ owl:unionOf (:X3DNBodyCollisionSpaceNode :X3DNBodyCollidableNode) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCollidablesHasParentCollisionCollection a owl:ObjectProperty ;
+  owl:inverseOf :hasCollidables ;
+  rdfs:subPropertyOf :hasParentCollisionCollection .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFBool .
+:frictionCoefficients a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFVec2f .
+:minBounceSpeed a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFFloat .
+:slipFactors a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFVec2f .
+:softnessConstantForceMix a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFFloat .
+:softnessErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFFloat .
+:surfaceSpeed a owl:DatatypeProperty ;
+  rdfs:domain :CollisionCollection ;
+  rdfs:range :SFVec2f .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CollisionSensor a owl:Class ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "CollisionSensor generates collision-detection events." .
+:hasCollider a owl:ObjectProperty ;
+  rdfs:domain :CollisionSensor ;
+  rdfs:range :CollisionCollection ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColliderHasParentCollisionSensor a owl:ObjectProperty ;
+  owl:inverseOf :hasCollider ;
+  rdfs:subPropertyOf :hasParentCollisionSensor .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CollisionSpace a owl:Class ;
+  rdfs:subClassOf :X3DNBodyCollisionSpaceNode ;
+  rdfs:label "CollisionSpace holds collection of objects considered together for resolution of inter-object collisions." .
+# bboxCenter field inheritedFrom=X3DNBodyCollisionSpaceNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DNBodyCollisionSpaceNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:hasCollidables a owl:ObjectProperty ;
+  rdfs:domain :CollisionSpace ;
+  rdfs:range  [ owl:unionOf (:X3DNBodyCollisionSpaceNode :X3DNBodyCollidableNode) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCollidablesHasParentCollisionSpace a owl:ObjectProperty ;
+  owl:inverseOf :hasCollidables ;
+  rdfs:subPropertyOf :hasParentCollisionSpace .
+# displayBBox field inheritedFrom=X3DNBodyCollisionSpaceNode with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DNBodyCollisionSpaceNode with accessType=inputOutput, type=SFBool, default=true
+:useGeometry a owl:DatatypeProperty ;
+  rdfs:domain :CollisionSpace ;
+  rdfs:range :SFBool .
+# visible field inheritedFrom=X3DNBodyCollisionSpaceNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Color a owl:Class ;
+  rdfs:subClassOf :X3DColorNode ;
+  rdfs:label "Color node defines a set of RGB color values that apply either to a sibling Coordinate|CoordinateDouble node, or else to a parent ElevationGrid node." .
+:color a owl:DatatypeProperty ;
+  rdfs:domain :Color ;
+  rdfs:range :MFColor .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ColorChaser a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "ColorChaser generates a series of SFColor values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :ColorChaser ;
+  rdfs:range :SFColor .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :ColorChaser ;
+  rdfs:range :SFColor .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ColorDamper a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "ColorDamper generates a series of RGB color values that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :ColorDamper ;
+  rdfs:range :SFColor .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :ColorDamper ;
+  rdfs:range :SFColor .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ColorInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "ColorInterpolator generates a range of color values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :ColorInterpolator ;
+  rdfs:range :MFColor .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ColorRGBA a owl:Class ;
+  rdfs:subClassOf :X3DColorNode ;
+  rdfs:label "ColorRGBA node defines a set of RGBA color values that apply either to a sibling Coordinate|CoordinateDouble node, or else to a parent ElevationGrid node." .
+:color a owl:DatatypeProperty ;
+  rdfs:domain :ColorRGBA ;
+  rdfs:range :MFColorRGBA .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ComposedCubeMapTexture a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentTextureNode ;
+  rdfs:label "ComposedCubeMapTexture is a texture node that defines a cubic environment map source as an explicit set of images drawn from individual 2D texture nodes." .
+:hasBack a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBackHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasBack ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+:hasBottom a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBottomHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasBottom ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+:hasFront a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFrontHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasFront ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+:hasLeft a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLeftHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasLeft ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+:hasRight a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRightHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasRight ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+:hasTop a owl:ObjectProperty ;
+  rdfs:domain :ComposedCubeMapTexture ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTopHasParentComposedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasTop ;
+  rdfs:subPropertyOf :hasParentComposedCubeMapTexture .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ComposedShader a owl:Class ;
+  rdfs:subClassOf :X3DShaderNode ;
+  rdfs:subClassOf :X3DProgrammableShaderObject ;
+  rdfs:label "ComposedShader can contain field declarations, but no CDATA section of plain-text source code, since programs are composed from child ShaderPart nodes." .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :ComposedShader ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentComposedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentComposedShader .
+# language field inheritedFrom=X3DShaderNode with accessType=initializeOnly, type=SFString, simpleType=shaderLanguageValues, baseType=xs:NMTOKEN
+:hasParts a owl:ObjectProperty ;
+  rdfs:domain :ComposedShader ;
+  rdfs:range :ShaderPart ;
+  rdfs:subPropertyOf :hasChild .
+:fieldPartsHasParentComposedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasParts ;
+  rdfs:subPropertyOf :hasParentComposedShader .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+:hasIS a owl:ObjectProperty ;
+  rdfs:domain :ComposedShader ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:fieldISHasParentComposedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasIS ;
+  rdfs:subPropertyOf :hasParentComposedShader .
+:hasMetadata a owl:ObjectProperty ;
+  rdfs:domain :ComposedShader ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMetadataHasParentComposedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasMetadata ;
+  rdfs:subPropertyOf :hasParentComposedShader .
+
+:ComposedTexture3D a owl:Class ;
+  rdfs:subClassOf :X3DTexture3DNode ;
+  rdfs:label "ComposedTexture3D defines a 3D image-based texture map as a collection of 2D texture sources at various depths." .
+# repeatR field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatS field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatT field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+:hasTexture a owl:ObjectProperty ;
+  rdfs:domain :ComposedTexture3D ;
+  rdfs:range :X3DTexture2DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTextureHasParentComposedTexture3D a owl:ObjectProperty ;
+  owl:inverseOf :hasTexture ;
+  rdfs:subPropertyOf :hasParentComposedTexture3D .
+# textureProperties field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ComposedVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "ComposedVolumeStyle allows compositing multiple rendering styles into single rendering pass." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:hasRenderStyle a owl:ObjectProperty ;
+  rdfs:domain :ComposedVolumeStyle ;
+  rdfs:range :X3DComposableVolumeRenderStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRenderStyleHasParentComposedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasRenderStyle ;
+  rdfs:subPropertyOf :hasParentComposedVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Cone a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Cone is a geometry node." .
+:bottom a owl:DatatypeProperty ;
+  rdfs:domain :Cone ;
+  rdfs:range :SFBool .
+:bottomRadius a owl:DatatypeProperty ;
+  rdfs:domain :Cone ;
+  rdfs:range :SFFloat .
+:height a owl:DatatypeProperty ;
+  rdfs:domain :Cone ;
+  rdfs:range :SFFloat .
+:side a owl:DatatypeProperty ;
+  rdfs:domain :Cone ;
+  rdfs:range :SFBool .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Cone ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ConeEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "ConeEmitter generates all available particles from a specific point in space." .
+:angle a owl:DatatypeProperty ;
+  rdfs:domain :ConeEmitter ;
+  rdfs:range :SFFloat .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :ConeEmitter ;
+  rdfs:range :SFVec3f .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :ConeEmitter ;
+  rdfs:range :SFVec3f .
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Contact a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Contact nodes are produced as output events when two collidable objects or spaces make contact." .
+:appliedParameters a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :appliedParametersChoices .
+:hasBody1 a owl:ObjectProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :RigidBody ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBody1HasParentContact a owl:ObjectProperty ;
+  owl:inverseOf :hasBody1 ;
+  rdfs:subPropertyOf :hasParentContact .
+:hasBody2 a owl:ObjectProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :RigidBody ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBody2HasParentContact a owl:ObjectProperty ;
+  owl:inverseOf :hasBody2 ;
+  rdfs:subPropertyOf :hasParentContact .
+:bounce a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFFloat .
+:contactNormal a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec3f .
+:depth a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFFloat .
+:frictionCoefficients a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec2f .
+:frictionDirection a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec3f .
+:hasGeometry1 a owl:ObjectProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :X3DNBodyCollidableNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometry1HasParentContact a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry1 ;
+  rdfs:subPropertyOf :hasParentContact .
+:hasGeometry2 a owl:ObjectProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :X3DNBodyCollidableNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometry2HasParentContact a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry2 ;
+  rdfs:subPropertyOf :hasParentContact .
+:minBounceSpeed a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFFloat .
+:position a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec3f .
+:slipCoefficients a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec2f .
+:softnessConstantForceMix a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFFloat .
+:softnessErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFFloat .
+:surfaceSpeed a owl:DatatypeProperty ;
+  rdfs:domain :Contact ;
+  rdfs:range :SFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Contour2D a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "Contour2D groups a set of curve segments into a composite contour." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :Contour2D ;
+  rdfs:range  [ owl:unionOf (:NurbsCurve2D :ContourPolyline2D) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentContour2D .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ContourPolyline2D a owl:Class ;
+  rdfs:subClassOf :X3DNurbsControlCurveNode ;
+  rdfs:label "ContourPolyline2D defines a linear curve segment as part of a trimming contour in the u-v domain of a NURBS surface." .
+# controlPoint field inheritedFrom=X3DNurbsControlCurveNode with accessType=inputOutput, type=MFVec2d
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Coordinate a owl:Class ;
+  rdfs:subClassOf :X3DCoordinateNode ;
+  rdfs:label "Coordinate builds geometry by defining a set of 3D coordinate (triplet) point values." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :Coordinate ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CoordinateChaser a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "CoordinateChaser generates a series of coordinate arrays that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateChaser ;
+  rdfs:range :MFVec3f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateChaser ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CoordinateDamper a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "CoordinateDamper generates a series of coordinate arrays that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateDamper ;
+  rdfs:range :MFVec3f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateDamper ;
+  rdfs:range :MFVec3f .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CoordinateDouble a owl:Class ;
+  rdfs:subClassOf :X3DCoordinateNode ;
+  rdfs:label "CoordinateDouble builds geometry by defining a set of 3D coordinate (triplet) point values." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateDouble ;
+  rdfs:range :MFVec3d .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CoordinateInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "CoordinateInterpolator linearly interpolates among a list of 3-tuple MFVec3f arrays, producing a single MFVec3f array that is fractional average between two nearest arrays in the list." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateInterpolator ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CoordinateInterpolator2D a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "CoordinateInterpolator2D generates a series of SFVec2f or MFVec2f 2-tuple float values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :CoordinateInterpolator2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Cylinder a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Cylinder is a geometry node." .
+:bottom a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFBool .
+:height a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFFloat .
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFFloat .
+:side a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFBool .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFBool .
+:top a owl:DatatypeProperty ;
+  rdfs:domain :Cylinder ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:CylinderSensor a owl:Class ;
+  rdfs:subClassOf :X3DDragSensorNode ;
+  rdfs:label "CylinderSensor converts pointer motion (for example, a mouse or wand) into rotation values using an invisible cylinder aligned with local Y-axis." .
+# autoOffset field inheritedFrom=X3DDragSensorNode with accessType=inputOutput, type=SFBool, default=true
+:axisRotation a owl:DatatypeProperty ;
+  rdfs:domain :CylinderSensor ;
+  rdfs:range :SFRotation .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+:diskAngle a owl:DatatypeProperty ;
+  rdfs:domain :CylinderSensor ;
+  rdfs:range :SFFloat .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:maxAngle a owl:DatatypeProperty ;
+  rdfs:domain :CylinderSensor ;
+  rdfs:range :SFFloat .
+:minAngle a owl:DatatypeProperty ;
+  rdfs:domain :CylinderSensor ;
+  rdfs:range :SFFloat .
+:offset a owl:DatatypeProperty ;
+  rdfs:domain :CylinderSensor ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:DirectionalLight a owl:Class ;
+  rdfs:subClassOf :X3DLightNode ;
+  rdfs:label "DirectionalLight might not be scoped by parent Group or Transform at levels 1 or 2." .
+# ambientIntensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=0, baseType=intensityType
+# color field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFColor, default=1 1 1
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :DirectionalLight ;
+  rdfs:range :SFVec3f .
+:global a owl:DatatypeProperty ;
+  rdfs:domain :DirectionalLight ;
+  rdfs:range :SFBool .
+# intensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=1, baseType=intensityType
+# on field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:DISEntityManager a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "DISEntityManager notifies a scene when new DIS ESPDU entities arrive or current entities leave." .
+:address a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityManager ;
+  rdfs:range :SFString .
+:applicationID a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityManager ;
+  rdfs:range :SFInt32 .
+:hasMapping a owl:ObjectProperty ;
+  rdfs:domain :DISEntityManager ;
+  rdfs:range :DISEntityTypeMapping ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMappingHasParentDISEntityManager a owl:ObjectProperty ;
+  owl:inverseOf :hasMapping ;
+  rdfs:subPropertyOf :hasParentDISEntityManager .
+:port a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityManager ;
+  rdfs:range :SFInt32 .
+:siteID a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityManager ;
+  rdfs:range :SFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:DISEntityTypeMapping a owl:Class ;
+  rdfs:subClassOf :X3DInfoNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "DISEntityTypeMapping provides a best-match mapping from DIS ESPDU entity type information to a specific X3D model, thus providing a visual and behavioral representation that best matches the entity type." .
+:category a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:country a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:domain a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:extra a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:kind a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:specific a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+:subcategory a owl:DatatypeProperty ;
+  rdfs:domain :DISEntityTypeMapping ;
+  rdfs:range :SFInt32 .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Disk2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Disk2D is a geometry node that defines a filled (or partially filled) planar circle with center (0,0)." .
+:innerRadius a owl:DatatypeProperty ;
+  rdfs:domain :Disk2D ;
+  rdfs:range :SFFloat .
+:outerRadius a owl:DatatypeProperty ;
+  rdfs:domain :Disk2D ;
+  rdfs:range :SFFloat .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Disk2D ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:DoubleAxisHingeJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "DoubleAxisHingeJoint has two independent axes located around a common anchor point." .
+:anchorPoint a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFVec3f .
+:axis1 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFVec3f .
+:axis2 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFVec3f .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+:desiredAngularVelocity1 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:desiredAngularVelocity2 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+:maxAngle1 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:maxTorque1 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:maxTorque2 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:minAngle1 a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:stop1Bounce a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:stop1ConstantForceMix a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:stop1ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:suspensionErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:suspensionForce a owl:DatatypeProperty ;
+  rdfs:domain :DoubleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:EaseInEaseOut a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "EaseInEaseOut enables gradual animation transitions by modifying TimeSensor fraction outputs." .
+:easeInEaseOut a owl:DatatypeProperty ;
+  rdfs:domain :EaseInEaseOut ;
+  rdfs:range :MFVec2f .
+:key a owl:DatatypeProperty ;
+  rdfs:domain :EaseInEaseOut ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:EdgeEnhancementVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "EdgeEnhancementVolumeStyle specifies edge enhancement for the volume rendering style." .
+:edgeColor a owl:DatatypeProperty ;
+  rdfs:domain :EdgeEnhancementVolumeStyle ;
+  rdfs:range :SFColorRGBA .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:gradientThreshold a owl:DatatypeProperty ;
+  rdfs:domain :EdgeEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+:hasSurfaceNormals a owl:ObjectProperty ;
+  rdfs:domain :EdgeEnhancementVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceNormalsHasParentEdgeEnhancementVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasSurfaceNormals ;
+  rdfs:subPropertyOf :hasParentEdgeEnhancementVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ElevationGrid a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "ElevationGrid is a geometry node defining a rectangular height field, with default values for a 1m by 1m square at height 0." .
+:hasAttrib a owl:ObjectProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :X3DVertexAttributeNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldAttribHasParentElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasAttrib ;
+  rdfs:subPropertyOf :hasParentElevationGrid .
+:ccw a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFBool .
+:hasColor a owl:ObjectProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorHasParentElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasColor ;
+  rdfs:subPropertyOf :hasParentElevationGrid .
+:colorPerVertex a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFBool .
+:creaseAngle a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFFloat .
+:hasFogCoord a owl:ObjectProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :FogCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFogCoordHasParentElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasFogCoord ;
+  rdfs:subPropertyOf :hasParentElevationGrid .
+:height a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :MFFloat .
+:hasNormal a owl:ObjectProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :X3DNormalNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldNormalHasParentElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasNormal ;
+  rdfs:subPropertyOf :hasParentElevationGrid .
+:normalPerVertex a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFBool .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFBool .
+:hasTexCoord a owl:ObjectProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :X3DTextureCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexCoordHasParentElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasTexCoord ;
+  rdfs:subPropertyOf :hasParentElevationGrid .
+:xDimension a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFInt32 .
+:xSpacing a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFFloat .
+:zDimension a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFInt32 .
+:zSpacing a owl:DatatypeProperty ;
+  rdfs:domain :ElevationGrid ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:EspduTransform a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:subClassOf :X3DNetworkSensorNode ;
+  rdfs:label "EspduTransform is a networked Transform node that can contain most nodes." .
+:address a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFString .
+:applicationID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:articulationParameterArray a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :MFFloat .
+:articulationParameterChangeIndicatorArray a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :MFInt32 .
+:articulationParameterCount a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:articulationParameterDesignatorArray a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :MFInt32 .
+:articulationParameterIdPartAttachedToArray a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :MFInt32 .
+:articulationParameterTypeArray a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :MFInt32 .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+:collisionType a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:deadReckoning a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:detonationLocation a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:detonationRelativeLocation a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:detonationResult a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFBool .
+:entityCategory a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entityCountry a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entityDomain a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entityExtra a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entityID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entityKind a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entitySpecific a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:entitySubcategory a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:eventApplicationID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:eventEntityID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:eventNumber a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:eventSiteID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:fired1 a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFBool .
+:fired2 a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFBool .
+:fireMissionIndex a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:firingRange a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFFloat .
+:firingRate a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:forceID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:fuse a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3d .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :geoSystemType .
+:linearAcceleration a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:linearVelocity a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:marking a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFString .
+:multicastRelayHost a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFString .
+:multicastRelayPort a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:munitionApplicationID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:munitionEndPoint a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:munitionEntityID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:munitionQuantity a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:munitionSiteID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:munitionStartPoint a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:networkMode a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :networkModeChoices .
+:port a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:readInterval a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFTime .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFRotation .
+:rtpHeaderExpected a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFBool .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFRotation .
+:siteID a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+:warhead a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFInt32 .
+:writeInterval a owl:DatatypeProperty ;
+  rdfs:domain :EspduTransform ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ExplosionEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "ExplosionEmitter generates all particles from a specific point in space at the initial time enabled." .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :ExplosionEmitter ;
+  rdfs:range :SFVec3f .
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Extrusion a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Extrusion is a geometry node that sequentially stretches a 2D cross section along a 3D-spine path in the local coordinate system, creating an outer hull." .
+:beginCap a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFBool .
+:ccw a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFBool .
+:convex a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFBool .
+:creaseAngle a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFFloat .
+:crossSection a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :MFVec2f .
+:endCap a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFBool .
+:orientation a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :MFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :MFVec2f .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :SFBool .
+:spine a owl:DatatypeProperty ;
+  rdfs:domain :Extrusion ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:FillProperties a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "FillProperties indicates whether appearance is filled or hatched for associated geometry nodes inside the same Shape." .
+:filled a owl:DatatypeProperty ;
+  rdfs:domain :FillProperties ;
+  rdfs:range :SFBool .
+:hatchColor a owl:DatatypeProperty ;
+  rdfs:domain :FillProperties ;
+  rdfs:range :SFColor .
+:hatched a owl:DatatypeProperty ;
+  rdfs:domain :FillProperties ;
+  rdfs:range :SFBool .
+:hatchStyle a owl:DatatypeProperty ;
+  rdfs:domain :FillProperties ;
+  rdfs:range :SFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:FloatVertexAttribute a owl:Class ;
+  rdfs:subClassOf :X3DVertexAttributeNode ;
+  rdfs:label "FloatVertexAttribute defines a set of per-vertex single-precision floating-point attributes." .
+# name field inheritedFrom=X3DVertexAttributeNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKEN
+:numComponents a owl:DatatypeProperty ;
+  rdfs:domain :FloatVertexAttribute ;
+  rdfs:range :SFInt32 .
+:value a owl:DatatypeProperty ;
+  rdfs:domain :FloatVertexAttribute ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Fog a owl:Class ;
+  rdfs:subClassOf :X3DBindableNode ;
+  rdfs:subClassOf :X3DFogObject ;
+  rdfs:label "Fog simulates atmospheric effects by blending distant objects with fog color." .
+# color field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFColor, default=1 1 1
+# fogType field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFString, default=LINEAR, simpleType=fogTypeChoices, baseType=xs:NMTOKEN
+# visibilityRange field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFFloat, default=0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:FogCoordinate a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "FogCoordinate defines a set of explicit fog depths on a per-vertex basis, overriding Fog visibilityRange." .
+:depth a owl:DatatypeProperty ;
+  rdfs:domain :FogCoordinate ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:FontStyle a owl:Class ;
+  rdfs:subClassOf :X3DFontStyleNode ;
+  rdfs:label "FontStyle is an X3DFontStyleNode that defines the size, family, justification, and other styles used by Text nodes." .
+:family a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :fontFamilyValues .
+:horizontal a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFBool .
+:justify a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :justifyChoices .
+:language a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFString .
+:leftToRight a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFBool .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFFloat .
+:spacing a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFFloat .
+:style a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :fontStyleChoices .
+:topToBottom a owl:DatatypeProperty ;
+  rdfs:domain :FontStyle ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ForcePhysicsModel a owl:Class ;
+  rdfs:subClassOf :X3DParticlePhysicsModelNode ;
+  rdfs:label "ForcePhysicsModel applies a constant force value to the particles." .
+# enabled field inheritedFrom=X3DParticlePhysicsModelNode with accessType=inputOutput, type=SFBool, default=true
+:force a owl:DatatypeProperty ;
+  rdfs:domain :ForcePhysicsModel ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeneratedCubeMapTexture a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentTextureNode ;
+  rdfs:label "GeneratedCubeMapTexture is a texture node that defines a cubic environment map that sources its data from internally generated images." .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :GeneratedCubeMapTexture ;
+  rdfs:range :SFInt32 .
+:hasTextureProperties a owl:ObjectProperty ;
+  rdfs:domain :GeneratedCubeMapTexture ;
+  rdfs:range :TextureProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexturePropertiesHasParentGeneratedCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasTextureProperties ;
+  rdfs:subPropertyOf :hasParentGeneratedCubeMapTexture .
+:update a owl:DatatypeProperty ;
+  rdfs:domain :GeneratedCubeMapTexture ;
+  rdfs:range :generatedCubeMapTextureUpdateChoices .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoCoordinate a owl:Class ;
+  rdfs:subClassOf :X3DCoordinateNode ;
+  rdfs:label "GeoCoordinate builds geometry as a set of geographic 3D coordinates." .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoCoordinate ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoCoordinate a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoCoordinate .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoCoordinate ;
+  rdfs:range :geoSystemType .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :GeoCoordinate ;
+  rdfs:range :MFVec3d .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoElevationGrid a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "GeoElevationGrid is a geometry node defining a rectangular height field, with default values for a 1m by 1m square at height 0." .
+:ccw a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFBool .
+:hasColor a owl:ObjectProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorHasParentGeoElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasColor ;
+  rdfs:subPropertyOf :hasParentGeoElevationGrid .
+:colorPerVertex a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFBool .
+:creaseAngle a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFDouble .
+:geoGridOrigin a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFVec3d .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoElevationGrid .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :geoSystemType .
+:height a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :MFDouble .
+:hasNormal a owl:ObjectProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :X3DNormalNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldNormalHasParentGeoElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasNormal ;
+  rdfs:subPropertyOf :hasParentGeoElevationGrid .
+:normalPerVertex a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFBool .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFBool .
+:hasTexCoord a owl:ObjectProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :X3DTextureCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexCoordHasParentGeoElevationGrid a owl:ObjectProperty ;
+  owl:inverseOf :hasTexCoord ;
+  rdfs:subPropertyOf :hasParentGeoElevationGrid .
+:xDimension a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFInt32 .
+:xSpacing a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFDouble .
+:yScale a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFFloat .
+:zDimension a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFInt32 .
+:zSpacing a owl:DatatypeProperty ;
+  rdfs:domain :GeoElevationGrid ;
+  rdfs:range :SFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoLocation a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "GeoLocation positions a regular X3D model onto earth's surface." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :GeoLocation ;
+  rdfs:range :SFVec3d .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoLocation ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoLocation a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoLocation .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoLocation ;
+  rdfs:range :geoSystemType .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoLOD a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "Note that MFNode rootNode field can contain multiple nodes and has accessType inputOutput. Meanwhile MFNode children field is outputOnly, unlike other X3DGroupingNode exemplars." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :SFVec3d .
+:child1Url a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :MFString .
+:child2Url a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :MFString .
+:child3Url a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :MFString .
+:child4Url a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :MFString .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoLOD a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoLOD .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :geoSystemType .
+:range a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :SFFloat .
+:hasRootNode a owl:ObjectProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRootNodeHasParentGeoLOD a owl:ObjectProperty ;
+  owl:inverseOf :hasRootNode ;
+  rdfs:subPropertyOf :hasParentGeoLOD .
+:rootUrl a owl:DatatypeProperty ;
+  rdfs:domain :GeoLOD ;
+  rdfs:range :MFString .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoMetadata a owl:Class ;
+  rdfs:subClassOf :X3DInfoNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "GeoMetadata includes a generic subset of metadata about the geographic data." .
+:hasData a owl:ObjectProperty ;
+  rdfs:domain :GeoMetadata ;
+  rdfs:range :X3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldDataHasParentGeoMetadata a owl:ObjectProperty ;
+  owl:inverseOf :hasData ;
+  rdfs:subPropertyOf :hasParentGeoMetadata .
+:summary a owl:DatatypeProperty ;
+  rdfs:domain :GeoMetadata ;
+  rdfs:range :MFString .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoOrigin a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "GeoOrigin is deprecated and discouraged (but nevertheless allowed) in X3D version 3.3. GeoOrigin is restored in X3D version 4.0 for special use on devices with limited floating-point resolution." .
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :GeoOrigin ;
+  rdfs:range :SFVec3d .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoOrigin ;
+  rdfs:range :geoSystemType .
+:rotateYUp a owl:DatatypeProperty ;
+  rdfs:domain :GeoOrigin ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoPositionInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "GeoPositionInterpolator animates objects within a geographic coordinate system." .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoPositionInterpolator ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoPositionInterpolator a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoPositionInterpolator .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoPositionInterpolator ;
+  rdfs:range :geoSystemType .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :GeoPositionInterpolator ;
+  rdfs:range :MFVec3d .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoProximitySensor a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentalSensorNode ;
+  rdfs:label "GeoProximitySensor generates events when the viewer enters, exits and moves within a region of space (defined by a box)." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :GeoProximitySensor ;
+  rdfs:range :SFVec3d .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:geoCenter a owl:DatatypeProperty ;
+  rdfs:domain :GeoProximitySensor ;
+  rdfs:range :SFVec3d .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoProximitySensor ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoProximitySensor a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoProximitySensor .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoProximitySensor ;
+  rdfs:range :geoSystemType .
+# size field inheritedFrom=X3DEnvironmentalSensorNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoTouchSensor a owl:Class ;
+  rdfs:subClassOf :X3DTouchSensorNode ;
+  rdfs:label "GeoTouchSensor returns geographic coordinates for the object being selected." .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoTouchSensor ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoTouchSensor a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoTouchSensor .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoTouchSensor ;
+  rdfs:range :geoSystemType .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoTransform a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "GeoTransform is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:geoCenter a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :SFVec3d .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoTransform a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoTransform .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :geoSystemType .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :SFRotation .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :GeoTransform ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:GeoViewpoint a owl:Class ;
+  rdfs:subClassOf :X3DViewpointNode ;
+  rdfs:label "GeoViewpoint specifies viewpoints using geographic coordinates." .
+:centerOfRotation a owl:DatatypeProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :SFVec3d .
+# description field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFString
+:fieldOfView a owl:DatatypeProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :SFFloat .
+:hasGeoOrigin a owl:ObjectProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :GeoOrigin ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeoOriginHasParentGeoViewpoint a owl:ObjectProperty ;
+  owl:inverseOf :hasGeoOrigin ;
+  rdfs:subPropertyOf :hasParentGeoViewpoint .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :geoSystemType .
+# jump field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=true
+# orientation field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFRotation, default=0 0 1 0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :SFVec3d .
+# retainUserOffsets field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=false
+:speedFactor a owl:DatatypeProperty ;
+  rdfs:domain :GeoViewpoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Group a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "Group is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimDisplacer a owl:Class ;
+  rdfs:subClassOf :X3DGeometricPropertyNode ;
+  rdfs:label "HAnimDisplacer nodes alter the shape of coordinate-based geometry within parent HAnimJoint or HAnimSegment nodes." .
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :HAnimDisplacer ;
+  rdfs:range :MFInt32 .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimDisplacer ;
+  rdfs:range :SFString .
+:displacements a owl:DatatypeProperty ;
+  rdfs:domain :HAnimDisplacer ;
+  rdfs:range :MFVec3f .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :HAnimDisplacer ;
+  rdfs:range :hanimFeaturePointNameValues .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :HAnimDisplacer ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimHumanoid a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "The HAnimHumanoid node is used to: (a) store references to the joints, segments, sites, skeleton, optional skin, and fixed viewpoints, (b) serve as a container for the entire humanoid, (c) provide a convenient way of moving the humanoid through its environment, and (d) store human-readable metadata such as name, version, author, copyright, age, gender and other information." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFVec3f .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFString .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:info a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :MFString .
+:jointBindingPositions a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :MFVec3f .
+:jointBindingRotations a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :MFRotation .
+:jointBindingScales a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :MFVec3f .
+:hasJoints a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :HAnimJoint ;
+  rdfs:subPropertyOf :hasChild .
+:fieldJointsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasJoints ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:loa a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :loaType .
+:hasMotions a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :HAnimMotion ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMotionsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasMotions ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range xs:NMTOKEN .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFRotation .
+:hasSegments a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :HAnimSegment ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSegmentsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSegments ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSites a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :HAnimSite ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSitesHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSites ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:skeletalConfiguration a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFString .
+:hasSkeleton a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range  [ owl:unionOf (:HAnimJoint :HAnimSite) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkeletonHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkeleton ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSkin a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range  [ owl:unionOf (:Group :Transform :Shape :IndexedFaceSet) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkinHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkin ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSkinBindingCoords a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkinBindingCoordsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkinBindingCoords ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSkinBindingNormals a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :X3DNormalNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkinBindingNormalsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkinBindingNormals ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSkinCoord a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkinCoordHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkinCoord ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:hasSkinNormal a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :X3DNormalNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSkinNormalHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasSkinNormal ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :SFVec3f .
+:version a owl:DatatypeProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :hanimVersionChoices .
+:hasViewpoints a owl:ObjectProperty ;
+  rdfs:domain :HAnimHumanoid ;
+  rdfs:range :HAnimSite ;
+  rdfs:subPropertyOf :hasChild .
+:fieldViewpointsHasParentHAnimHumanoid a owl:ObjectProperty ;
+  owl:inverseOf :hasViewpoints ;
+  rdfs:subPropertyOf :hasParentHAnimHumanoid .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimJoint a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "HAnimJoint node can represent each joint in a body." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range  [ owl:unionOf (:HAnimJoint :HAnimSegment :HAnimSite) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentHAnimJoint .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFString .
+:hasDisplacers a owl:ObjectProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :HAnimDisplacer ;
+  rdfs:subPropertyOf :hasChild .
+:fieldDisplacersHasParentHAnimJoint a owl:ObjectProperty ;
+  owl:inverseOf :hasDisplacers ;
+  rdfs:subPropertyOf :hasParentHAnimJoint .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:limitOrientation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFRotation .
+:llimit a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :hanimJointNameValues .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFRotation .
+:skinCoordIndex a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :MFInt32 .
+:skinCoordWeight a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :MFFloat .
+:stiffness a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+:ulimit a owl:DatatypeProperty ;
+  rdfs:domain :HAnimJoint ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimMotion a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "An HAnimMotion node supports discrete frame-by-frame playback for H-Anim motion data animation." .
+:channels a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :MFString .
+:channelsEnabled a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :MFBool .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFString .
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFBool .
+:endFrame a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFInt32 .
+:frameDuration a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFTime .
+:frameIncrement a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFInt32 .
+:frameIndex a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFInt32 .
+:joints a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :MFString .
+:loa a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :loaType .
+:loop a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFBool .
+:startFrame a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :SFInt32 .
+:values a owl:DatatypeProperty ;
+  rdfs:domain :HAnimMotion ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimSegment a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "HAnimSegment node contains Shape geometry for each body segment." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:centerOfMass a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :SFVec3f .
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentHAnimSegment a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentHAnimSegment .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :SFString .
+:hasDisplacers a owl:ObjectProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :HAnimDisplacer ;
+  rdfs:subPropertyOf :hasChild .
+:fieldDisplacersHasParentHAnimSegment a owl:ObjectProperty ;
+  owl:inverseOf :hasDisplacers ;
+  rdfs:subPropertyOf :hasParentHAnimSegment .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:mass a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :SFFloat .
+:momentsOfInertia a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :MFFloat .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSegment ;
+  rdfs:range :hanimSegmentNameValues .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:HAnimSite a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "An HAnimSite node serves three purposes: (a) define an end effector location which can be used by an inverse kinematics system, (b) define an attachment point for accessories such as jewelry and clothing, and (c) define a location for a Viewpoint virtual camera in the reference frame of an HAnimSegment (such as a view through the eyes of the humanoid for use in multi-user worlds)." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFVec3f .
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+:description a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFString .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:name a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :hanimFeaturePointNameValues .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFRotation .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :HAnimSite ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ImageCubeMapTexture a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentTextureNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "ImageCubeMapTexture is a texture node that defines a cubic environment map source as a single file format that contains multiple images, one for each side." .
+:hasTextureProperties a owl:ObjectProperty ;
+  rdfs:domain :ImageCubeMapTexture ;
+  rdfs:range :TextureProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexturePropertiesHasParentImageCubeMapTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasTextureProperties ;
+  rdfs:subPropertyOf :hasParentImageCubeMapTexture .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ImageTexture a owl:Class ;
+  rdfs:subClassOf :X3DTexture2DNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "ImageTexture maps a 2D-image file onto a geometric shape." .
+# repeatS field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# repeatT field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# textureProperties field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFNode, default=NULL
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ImageTexture3D a owl:Class ;
+  rdfs:subClassOf :X3DTexture3DNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "ImageTexture3D defines a 3D image-based texture map by specifying a single image file that contains complete 3D data." .
+# repeatR field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatS field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatT field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# textureProperties field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFNode, default=NULL
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedFaceSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "IndexedFaceSet defines polygons using index lists corresponding to vertex coordinates." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:colorIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :MFInt32 .
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+:convex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :SFBool .
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :MFInt32 .
+:creaseAngle a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :SFFloat .
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:normalIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :MFInt32 .
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:texCoordIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedFaceSet ;
+  rdfs:range :MFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedLineSet a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "IndexedLineSet defines polyline segments using index lists corresponding to vertex coordinates." .
+:hasAttrib a owl:ObjectProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :X3DVertexAttributeNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldAttribHasParentIndexedLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasAttrib ;
+  rdfs:subPropertyOf :hasParentIndexedLineSet .
+:hasColor a owl:ObjectProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorHasParentIndexedLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasColor ;
+  rdfs:subPropertyOf :hasParentIndexedLineSet .
+:colorIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :MFInt32 .
+:colorPerVertex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :SFBool .
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentIndexedLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentIndexedLineSet .
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :MFInt32 .
+:hasFogCoord a owl:ObjectProperty ;
+  rdfs:domain :IndexedLineSet ;
+  rdfs:range :FogCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFogCoordHasParentIndexedLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasFogCoord ;
+  rdfs:subPropertyOf :hasParentIndexedLineSet .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedQuadSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "IndexedQuadSet is a geometry node that defines quadrilaterals." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:index a owl:DatatypeProperty ;
+  rdfs:domain :IndexedQuadSet ;
+  rdfs:range :MFInt32 .
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedTriangleFanSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "IndexedTriangleFanSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:index a owl:DatatypeProperty ;
+  rdfs:domain :IndexedTriangleFanSet ;
+  rdfs:range :MFInt32 .
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedTriangleSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "IndexedTriangleSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:index a owl:DatatypeProperty ;
+  rdfs:domain :IndexedTriangleSet ;
+  rdfs:range :MFInt32 .
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IndexedTriangleStripSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "IndexedTriangleStripSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:index a owl:DatatypeProperty ;
+  rdfs:domain :IndexedTriangleStripSet ;
+  rdfs:range :MFInt32 .
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Inline a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "Inline can load another X3D or VRML model into the current scene via url." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:load a owl:DatatypeProperty ;
+  rdfs:domain :Inline ;
+  rdfs:range :SFBool .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IntegerSequencer a owl:Class ;
+  rdfs:subClassOf :X3DSequencerNode ;
+  rdfs:label "IntegerSequencer generates periodic discrete integer values." .
+# key field inheritedFrom=X3DSequencerNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :IntegerSequencer ;
+  rdfs:range :MFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IntegerTrigger a owl:Class ;
+  rdfs:subClassOf :X3DTriggerNode ;
+  rdfs:label "IntegerTrigger converts set_boolean true input events to an integer value (for example, useful when animating whichChoice in a Switch node)." .
+:integerKey a owl:DatatypeProperty ;
+  rdfs:domain :IntegerTrigger ;
+  rdfs:range :SFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:IsoSurfaceVolumeData a owl:Class ;
+  rdfs:subClassOf :X3DVolumeDataNode ;
+  rdfs:label "IsoSurfaceVolumeData displays one or more surfaces extracted from a voxel dataset." .
+# bboxCenter field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:contourStepSize a owl:DatatypeProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :SFFloat .
+# dimensions field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFVec3f, default=1 1 1
+# displayBBox field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=false
+:hasGradients a owl:ObjectProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGradientsHasParentIsoSurfaceVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasGradients ;
+  rdfs:subPropertyOf :hasParentIsoSurfaceVolumeData .
+:hasRenderStyle a owl:ObjectProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :X3DVolumeRenderStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRenderStyleHasParentIsoSurfaceVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasRenderStyle ;
+  rdfs:subPropertyOf :hasParentIsoSurfaceVolumeData .
+:surfaceTolerance a owl:DatatypeProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :SFFloat .
+:surfaceValues a owl:DatatypeProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :MFFloat .
+# visible field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=true
+:hasVoxels a owl:ObjectProperty ;
+  rdfs:domain :IsoSurfaceVolumeData ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldVoxelsHasParentIsoSurfaceVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasVoxels ;
+  rdfs:subPropertyOf :hasParentIsoSurfaceVolumeData .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:KeySensor a owl:Class ;
+  rdfs:subClassOf :X3DKeyDeviceSensorNode ;
+  rdfs:label "KeySensor generates events as the user presses keys on the keyboard." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Layer a owl:Class ;
+  rdfs:subClassOf :X3DLayerNode ;
+  rdfs:label "Layer contains a list of children nodes that define the contents of the layer." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :Layer ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentLayer .
+# objectType field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickable field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFBool, default=true
+# viewport field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFNode, default=NULL
+# visible field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LayerSet a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "LayerSet defines a list of layers and a rendering order." .
+:activeLayer a owl:DatatypeProperty ;
+  rdfs:domain :LayerSet ;
+  rdfs:range :SFInt32 .
+:hasLayers a owl:ObjectProperty ;
+  rdfs:domain :LayerSet ;
+  rdfs:range :X3DLayerNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLayersHasParentLayerSet a owl:ObjectProperty ;
+  owl:inverseOf :hasLayers ;
+  rdfs:subPropertyOf :hasParentLayerSet .
+:order a owl:DatatypeProperty ;
+  rdfs:domain :LayerSet ;
+  rdfs:range :MFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Layout a owl:Class ;
+  rdfs:subClassOf :X3DLayoutNode ;
+  rdfs:label "Layout node is used as layout field of LayoutLayer and LayoutGroup nodes." .
+:align a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :layoutAlignChoices .
+:offset a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :MFFloat .
+:offsetUnits a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :layoutUnitsChoices .
+:scaleMode a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :layoutScaleModeChoices .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :MFFloat .
+:sizeUnits a owl:DatatypeProperty ;
+  rdfs:domain :Layout ;
+  rdfs:range :layoutUnitsChoices .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LayoutGroup a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "LayoutGroup is a Grouping node that can contain most nodes, whose children are related by a common layout within a parent layout." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :LayoutGroup ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentLayoutGroup .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:hasLayout a owl:ObjectProperty ;
+  rdfs:domain :LayoutGroup ;
+  rdfs:range :X3DLayoutNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLayoutHasParentLayoutGroup a owl:ObjectProperty ;
+  owl:inverseOf :hasLayout ;
+  rdfs:subPropertyOf :hasParentLayoutGroup .
+:hasViewport a owl:ObjectProperty ;
+  rdfs:domain :LayoutGroup ;
+  rdfs:range :X3DViewportNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldViewportHasParentLayoutGroup a owl:ObjectProperty ;
+  owl:inverseOf :hasViewport ;
+  rdfs:subPropertyOf :hasParentLayoutGroup .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LayoutLayer a owl:Class ;
+  rdfs:subClassOf :X3DLayerNode ;
+  rdfs:label "LayoutLayer is a Grouping node that can contain most nodes." .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :LayoutLayer ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentLayoutLayer .
+:hasLayout a owl:ObjectProperty ;
+  rdfs:domain :LayoutLayer ;
+  rdfs:range :X3DLayoutNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLayoutHasParentLayoutLayer a owl:ObjectProperty ;
+  owl:inverseOf :hasLayout ;
+  rdfs:subPropertyOf :hasParentLayoutLayer .
+# objectType field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickable field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFBool, default=true
+# viewport field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFNode, default=NULL
+# visible field inheritedFrom=X3DLayerNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LinePickSensor a owl:Class ;
+  rdfs:subClassOf :X3DPickSensorNode ;
+  rdfs:label "LinePickSensor uses one or more pickingGeometry line segments to compute intersections with pickTarget shapes." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# intersectionType field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=BOUNDS, simpleType=intersectionTypeValues, baseType=xs:NMTOKEN
+# matchCriterion field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFString, default=MATCH_ANY, simpleType=pickSensorMatchCriterionChoices, baseType=xs:NMTOKEN
+# objectType field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickingGeometry field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFNode, default=NULL
+# pickTarget field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFNode
+# sortOrder field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=CLOSEST, simpleType=pickSensorSortOrderValues, baseType=xs:NMTOKEN
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LineProperties a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "LineProperties allows precise fine-grained control over the rendering style of lines and edges for associated geometry nodes inside the same Shape." .
+:applied a owl:DatatypeProperty ;
+  rdfs:domain :LineProperties ;
+  rdfs:range :SFBool .
+:linetype a owl:DatatypeProperty ;
+  rdfs:domain :LineProperties ;
+  rdfs:range :SFInt32 .
+:linewidthScaleFactor a owl:DatatypeProperty ;
+  rdfs:domain :LineProperties ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LineSet a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "LineSet is a geometry node that can contain a Coordinate|CoordinateDouble node and optionally a Color|ColorRGBA node." .
+:hasAttrib a owl:ObjectProperty ;
+  rdfs:domain :LineSet ;
+  rdfs:range :X3DVertexAttributeNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldAttribHasParentLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasAttrib ;
+  rdfs:subPropertyOf :hasParentLineSet .
+:hasColor a owl:ObjectProperty ;
+  rdfs:domain :LineSet ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorHasParentLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasColor ;
+  rdfs:subPropertyOf :hasParentLineSet .
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :LineSet ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentLineSet .
+:hasFogCoord a owl:ObjectProperty ;
+  rdfs:domain :LineSet ;
+  rdfs:range :FogCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFogCoordHasParentLineSet a owl:ObjectProperty ;
+  owl:inverseOf :hasFogCoord ;
+  rdfs:subPropertyOf :hasParentLineSet .
+:vertexCount a owl:DatatypeProperty ;
+  rdfs:domain :LineSet ;
+  rdfs:range :MFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LoadSensor a owl:Class ;
+  rdfs:subClassOf :X3DNetworkSensorNode ;
+  rdfs:label "LoadSensor generates events as watchList child nodes are either loaded or fail to load." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:timeOut a owl:DatatypeProperty ;
+  rdfs:domain :LoadSensor ;
+  rdfs:range :SFTime .
+:hasWatchList a owl:ObjectProperty ;
+  rdfs:domain :LoadSensor ;
+  rdfs:range :X3DUrlObject ;
+  rdfs:subPropertyOf :hasChild .
+:fieldWatchListHasParentLoadSensor a owl:ObjectProperty ;
+  owl:inverseOf :hasWatchList ;
+  rdfs:subPropertyOf :hasParentLoadSensor .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LocalFog a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DFogObject ;
+  rdfs:label "LocalFog simulates atmospheric effects by blending distant objects with fog color." .
+# color field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFColor, default=1 1 1
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :LocalFog ;
+  rdfs:range :SFBool .
+# fogType field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFString, default=LINEAR, simpleType=fogTypeChoices, baseType=xs:NMTOKEN
+# visibilityRange field inheritedFrom=X3DFogObject with accessType=inputOutput, type=SFFloat, default=0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:LOD a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "LOD (Level Of Detail) uses camera-to-object distance to switch among contained child levels." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :LOD ;
+  rdfs:range :SFVec3f .
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:forceTransitions a owl:DatatypeProperty ;
+  rdfs:domain :LOD ;
+  rdfs:range :SFBool .
+:range a owl:DatatypeProperty ;
+  rdfs:domain :LOD ;
+  rdfs:range :MFFloat .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Material a owl:Class ;
+  rdfs:subClassOf :X3DMaterialNode ;
+  rdfs:label "Material specifies surface rendering properties for associated geometry nodes." .
+:ambientIntensity a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :intensityType .
+:diffuseColor a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :SFColor .
+:emissiveColor a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :SFColor .
+:shininess a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :intensityType .
+:specularColor a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :SFColor .
+:transparency a owl:DatatypeProperty ;
+  rdfs:domain :Material ;
+  rdfs:range :intensityType .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Matrix3VertexAttribute a owl:Class ;
+  rdfs:subClassOf :X3DVertexAttributeNode ;
+  rdfs:label "Matrix3VertexAttribute defines a set of per-vertex 3x3 matrix attributes." .
+# name field inheritedFrom=X3DVertexAttributeNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKEN
+:value a owl:DatatypeProperty ;
+  rdfs:domain :Matrix3VertexAttribute ;
+  rdfs:range :MFMatrix3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Matrix4VertexAttribute a owl:Class ;
+  rdfs:subClassOf :X3DVertexAttributeNode ;
+  rdfs:label "Matrix4VertexAttribute defines a set of per-vertex 4x4 matrix attributes." .
+# name field inheritedFrom=X3DVertexAttributeNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKEN
+:value a owl:DatatypeProperty ;
+  rdfs:domain :Matrix4VertexAttribute ;
+  rdfs:range :MFMatrix4f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MetadataBoolean a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the Boolean values of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:value a owl:DatatypeProperty ;
+  rdfs:domain :MetadataBoolean ;
+  rdfs:range :MFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MetadataDouble a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the double-precision floating point numbers of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:value a owl:DatatypeProperty ;
+  rdfs:domain :MetadataDouble ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MetadataFloat a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the single-precision floating point numbers of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:value a owl:DatatypeProperty ;
+  rdfs:domain :MetadataFloat ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MetadataInteger a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the integer numbers of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:value a owl:DatatypeProperty ;
+  rdfs:domain :MetadataInteger ;
+  rdfs:range :MFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MetadataSet a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the metadata nodes of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:hasValue a owl:ObjectProperty ;
+  rdfs:domain :MetadataSet ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+:fieldValueHasParentMetadataSet a owl:ObjectProperty ;
+  owl:inverseOf :hasValue ;
+  rdfs:subPropertyOf :hasParentMetadataSet .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+:hasIS a owl:ObjectProperty ;
+  rdfs:domain :MetadataSet ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:fieldISHasParentMetadataSet a owl:ObjectProperty ;
+  owl:inverseOf :hasIS ;
+  rdfs:subPropertyOf :hasParentMetadataSet .
+:hasMetadata a owl:ObjectProperty ;
+  rdfs:domain :MetadataSet ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMetadataHasParentMetadataSet a owl:ObjectProperty ;
+  owl:inverseOf :hasMetadata ;
+  rdfs:subPropertyOf :hasParentMetadataSet .
+
+:MetadataString a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DMetadataObject ;
+  rdfs:label "The metadata provided by this node is contained in the strings of the value field." .
+# name field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+# reference field inheritedFrom=X3DMetadataObject with accessType=inputOutput, type=SFString
+:value a owl:DatatypeProperty ;
+  rdfs:domain :MetadataString ;
+  rdfs:range :MFString .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MotorJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "MotorJoint drives relative angular velocities between body1 and body2 within a common reference frame." .
+:autoCalc a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFBool .
+:axis1Angle a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:axis1Torque a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:axis2Angle a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:axis2Torque a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:axis3Angle a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:axis3Torque a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+:enabledAxes a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFInt32 .
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+:motor1Axis a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFVec3f .
+:motor2Axis a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFVec3f .
+:motor3Axis a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFVec3f .
+:stop1Bounce a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:stop1ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:stop2Bounce a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:stop2ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:stop3Bounce a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+:stop3ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :MotorJoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MovieTexture a owl:Class ;
+  rdfs:subClassOf :X3DSoundSourceNode ;
+  rdfs:subClassOf :X3DTexture2DNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "MovieTexture applies a 2D movie image to surface geometry, or provides audio for a Sound node." .
+# description field inheritedFrom=X3DSoundSourceNode with accessType=inputOutput, type=SFString
+# loop field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFBool, default=false
+# pauseTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# pitch field inheritedFrom=X3DSoundSourceNode with accessType=inputOutput, type=SFFloat, default=1.0
+# repeatS field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# repeatT field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# resumeTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+:speed a owl:DatatypeProperty ;
+  rdfs:domain :MovieTexture ;
+  rdfs:range :SFFloat .
+# startTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# stopTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+:hasTextureProperties a owl:ObjectProperty ;
+  rdfs:domain :MovieTexture ;
+  rdfs:range :TextureProperties ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexturePropertiesHasParentMovieTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasTextureProperties ;
+  rdfs:subPropertyOf :hasParentMovieTexture .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MultiTexture a owl:Class ;
+  rdfs:subClassOf :X3DTextureNode ;
+  rdfs:label "MultiTexture applies several individual textures to a single geometry node, enabling a variety of visual effects that include light mapping and environment mapping." .
+:alpha a owl:DatatypeProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :SFFloat .
+:color a owl:DatatypeProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :SFColor .
+:function a owl:DatatypeProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :multiTextureFunctionValues .
+:mode a owl:DatatypeProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :multiTextureModeValues .
+:source a owl:DatatypeProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :multiTextureSourceValues .
+:hasTexture a owl:ObjectProperty ;
+  rdfs:domain :MultiTexture ;
+  rdfs:range :X3DTextureNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTextureHasParentMultiTexture a owl:ObjectProperty ;
+  owl:inverseOf :hasTexture ;
+  rdfs:subPropertyOf :hasParentMultiTexture .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MultiTextureCoordinate a owl:Class ;
+  rdfs:subClassOf :X3DTextureCoordinateNode ;
+  rdfs:label "MultiTextureCoordinate contains multiple TextureCoordinate or TextureCoordinateGenerator nodes, for use by a parent polygonal geometry node such as IndexedFaceSet or a Triangle* node." .
+:hasTexCoord a owl:ObjectProperty ;
+  rdfs:domain :MultiTextureCoordinate ;
+  rdfs:range :X3DTextureCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexCoordHasParentMultiTextureCoordinate a owl:ObjectProperty ;
+  owl:inverseOf :hasTexCoord ;
+  rdfs:subPropertyOf :hasParentMultiTextureCoordinate .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:MultiTextureTransform a owl:Class ;
+  rdfs:subClassOf :X3DTextureTransformNode ;
+  rdfs:label "MultiTextureTransform contains multiple TextureTransform nodes, each provided for use by corresponding ImageTexture MovieTexture or PixelTexture nodes within a sibling MultiTexture node." .
+:hasTextureTransform a owl:ObjectProperty ;
+  rdfs:domain :MultiTextureTransform ;
+  rdfs:range :X3DTextureTransformNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTextureTransformHasParentMultiTextureTransform a owl:ObjectProperty ;
+  owl:inverseOf :hasTextureTransform ;
+  rdfs:subPropertyOf :hasParentMultiTextureTransform .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NavigationInfo a owl:Class ;
+  rdfs:subClassOf :X3DBindableNode ;
+  rdfs:label "NavigationInfo describes the user's viewing model, user navigation-interaction modalities, and also dimensional characteristics of the user's (typically invisible) avatar." .
+:avatarSize a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :MFFloat .
+:headlight a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :SFBool .
+:speed a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :SFFloat .
+:transitionTime a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :SFTime .
+:transitionType a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :navigationTransitionTypeValues .
+:type a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :navigationTypeValues .
+:visibilityLimit a owl:DatatypeProperty ;
+  rdfs:domain :NavigationInfo ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Normal a owl:Class ;
+  rdfs:subClassOf :X3DNormalNode ;
+  rdfs:label "Normal defines a set of 3D surface-normal vectors that apply either to a sibling Coordinate|CoordinateDouble node, or else to a parent ElevationGrid node." .
+:vector a owl:DatatypeProperty ;
+  rdfs:domain :Normal ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NormalInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "NormalInterpolator generates a series of normal (perpendicular) 3-tuple SFVec3f values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :NormalInterpolator ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsCurve a owl:Class ;
+  rdfs:subClassOf :X3DParametricGeometryNode ;
+  rdfs:label "NurbsCurve is a 3D curve analogous to NurbsPatchSurface." .
+:closed a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :SFBool .
+:hasControlPoint a owl:ObjectProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldControlPointHasParentNurbsCurve a owl:ObjectProperty ;
+  owl:inverseOf :hasControlPoint ;
+  rdfs:subPropertyOf :hasParentNurbsCurve .
+:knot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :MFDouble .
+:order a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :SFInt32 .
+:tessellation a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsCurve2D a owl:Class ;
+  rdfs:subClassOf :X3DNurbsControlCurveNode ;
+  rdfs:label "NurbsCurve2D defines a trimming segment that is part of a trimming contour in the u-v domain of a surface." .
+:closed a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve2D ;
+  rdfs:range :SFBool .
+# controlPoint field inheritedFrom=X3DNurbsControlCurveNode with accessType=inputOutput, type=MFVec2d
+:knot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve2D ;
+  rdfs:range :MFDouble .
+:order a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve2D ;
+  rdfs:range :SFInt32 .
+:tessellation a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve2D ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsCurve2D ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsOrientationInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "NurbsOrientationInterpolator describes a 3D NURBS curve and outputs interpolated orientation values." .
+:hasControlPoint a owl:ObjectProperty ;
+  rdfs:domain :NurbsOrientationInterpolator ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldControlPointHasParentNurbsOrientationInterpolator a owl:ObjectProperty ;
+  owl:inverseOf :hasControlPoint ;
+  rdfs:subPropertyOf :hasParentNurbsOrientationInterpolator .
+:knot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsOrientationInterpolator ;
+  rdfs:range :MFDouble .
+:order a owl:DatatypeProperty ;
+  rdfs:domain :NurbsOrientationInterpolator ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsOrientationInterpolator ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsPatchSurface a owl:Class ;
+  rdfs:subClassOf :X3DNurbsSurfaceGeometryNode ;
+  rdfs:label "NurbsPatchSurface defines a contiguous 3D Non-Uniform Rational B-Spline (NURBS) surface." .
+# controlPoint field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# solid field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# uClosed field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=false
+# uDimension field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=0
+# uKnot field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=MFDouble
+# uOrder field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=3
+# uTessellation field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFInt32, default=0
+# vClosed field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=false
+# vDimension field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=0
+# vKnot field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=MFDouble
+# vOrder field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=3
+# vTessellation field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFInt32, default=0
+# weight field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=MFDouble
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsPositionInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "NurbsPositionInterpolator describes a 3D NURBS curve and outputs interpolated position values." .
+:hasControlPoint a owl:ObjectProperty ;
+  rdfs:domain :NurbsPositionInterpolator ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldControlPointHasParentNurbsPositionInterpolator a owl:ObjectProperty ;
+  owl:inverseOf :hasControlPoint ;
+  rdfs:subPropertyOf :hasParentNurbsPositionInterpolator .
+:knot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsPositionInterpolator ;
+  rdfs:range :MFDouble .
+:order a owl:DatatypeProperty ;
+  rdfs:domain :NurbsPositionInterpolator ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsPositionInterpolator ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsSet a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "NurbsSet collects a set of NurbsSurface nodes into a common group and treats NurbsSurface set as a unit during tessellation, thereby enforcing tessellation continuity along borders." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+:hasGeometry a owl:ObjectProperty ;
+  rdfs:domain :NurbsSet ;
+  rdfs:range :X3DNurbsSurfaceGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometryHasParentNurbsSet a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry ;
+  rdfs:subPropertyOf :hasParentNurbsSet .
+:tessellationScale a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSet ;
+  rdfs:range :SFFloat .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsSurfaceInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "NurbsSurfaceInterpolator describes a 3D NURBS curve and outputs interpolated position and normal values." .
+:hasControlPoint a owl:ObjectProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldControlPointHasParentNurbsSurfaceInterpolator a owl:ObjectProperty ;
+  owl:inverseOf :hasControlPoint ;
+  rdfs:subPropertyOf :hasParentNurbsSurfaceInterpolator .
+:uDimension a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :SFInt32 .
+:uKnot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :MFDouble .
+:uOrder a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :SFInt32 .
+:vDimension a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :SFInt32 .
+:vKnot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :MFDouble .
+:vOrder a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSurfaceInterpolator ;
+  rdfs:range :MFDouble .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsSweptSurface a owl:Class ;
+  rdfs:subClassOf :X3DParametricGeometryNode ;
+  rdfs:label "NurbsSweptSurface contains a crossSectionCurve and a trajectoryCurve [NurbsCurve]." .
+:ccw a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSweptSurface ;
+  rdfs:range :SFBool .
+:hasCrossSectionCurve a owl:ObjectProperty ;
+  rdfs:domain :NurbsSweptSurface ;
+  rdfs:range :X3DNurbsControlCurveNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCrossSectionCurveHasParentNurbsSweptSurface a owl:ObjectProperty ;
+  owl:inverseOf :hasCrossSectionCurve ;
+  rdfs:subPropertyOf :hasParentNurbsSweptSurface .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSweptSurface ;
+  rdfs:range :SFBool .
+:hasTrajectoryCurve a owl:ObjectProperty ;
+  rdfs:domain :NurbsSweptSurface ;
+  rdfs:range :NurbsCurve ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTrajectoryCurveHasParentNurbsSweptSurface a owl:ObjectProperty ;
+  owl:inverseOf :hasTrajectoryCurve ;
+  rdfs:subPropertyOf :hasParentNurbsSweptSurface .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsSwungSurface a owl:Class ;
+  rdfs:subClassOf :X3DParametricGeometryNode ;
+  rdfs:label "NurbsSwungSurface contains a profileCurve and a trajectoryCurve [X3DNurbsControlCurveNode]." .
+:ccw a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSwungSurface ;
+  rdfs:range :SFBool .
+:hasProfileCurve a owl:ObjectProperty ;
+  rdfs:domain :NurbsSwungSurface ;
+  rdfs:range :X3DNurbsControlCurveNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldProfileCurveHasParentNurbsSwungSurface a owl:ObjectProperty ;
+  owl:inverseOf :hasProfileCurve ;
+  rdfs:subPropertyOf :hasParentNurbsSwungSurface .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :NurbsSwungSurface ;
+  rdfs:range :SFBool .
+:hasTrajectoryCurve a owl:ObjectProperty ;
+  rdfs:domain :NurbsSwungSurface ;
+  rdfs:range :X3DNurbsControlCurveNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTrajectoryCurveHasParentNurbsSwungSurface a owl:ObjectProperty ;
+  owl:inverseOf :hasTrajectoryCurve ;
+  rdfs:subPropertyOf :hasParentNurbsSwungSurface .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsTextureCoordinate a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "NurbsTextureCoordinate describes a 3D NURBS surface in the parametric domain of its surface host, specifying mapping of texture onto the surface." .
+:controlPoint a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :MFVec2f .
+:uDimension a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :SFInt32 .
+:uKnot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :MFDouble .
+:uOrder a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :SFInt32 .
+:vDimension a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :SFInt32 .
+:vKnot a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :MFDouble .
+:vOrder a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :SFInt32 .
+:weight a owl:DatatypeProperty ;
+  rdfs:domain :NurbsTextureCoordinate ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:NurbsTrimmedSurface a owl:Class ;
+  rdfs:subClassOf :X3DNurbsSurfaceGeometryNode ;
+  rdfs:label "NurbsTrimmedSurface generates texture coordinates from a Non-Uniform Rational B-Spline (NURBS) surface." .
+# controlPoint field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# solid field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:hasTrimmingContour a owl:ObjectProperty ;
+  rdfs:domain :NurbsTrimmedSurface ;
+  rdfs:range :Contour2D ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTrimmingContourHasParentNurbsTrimmedSurface a owl:ObjectProperty ;
+  owl:inverseOf :hasTrimmingContour ;
+  rdfs:subPropertyOf :hasParentNurbsTrimmedSurface .
+# uClosed field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=false
+# uDimension field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=0
+# uKnot field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=MFDouble
+# uOrder field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=3
+# uTessellation field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFInt32, default=0
+# vClosed field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFBool, default=false
+# vDimension field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=0
+# vKnot field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=MFDouble
+# vOrder field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=initializeOnly, type=SFInt32, default=3
+# vTessellation field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=SFInt32, default=0
+# weight field inheritedFrom=X3DNurbsSurfaceGeometryNode with accessType=inputOutput, type=MFDouble
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:OpacityMapVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "OpacityMapVolumeStyle specifies that volumetric data is rendered using opacity mapped to a transfer function texture." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:hasTransferFunction a owl:ObjectProperty ;
+  rdfs:domain :OpacityMapVolumeStyle ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :X3DTexture3DNode) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTransferFunctionHasParentOpacityMapVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasTransferFunction ;
+  rdfs:subPropertyOf :hasParentOpacityMapVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:OrientationChaser a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "OrientationChaser generates a series of 4-tuple axis-angle SFRotation values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :OrientationChaser ;
+  rdfs:range :SFRotation .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :OrientationChaser ;
+  rdfs:range :SFRotation .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:OrientationDamper a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "OrientationDamper generates a series of 4-tuple axis-angle SFRotation values that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :OrientationDamper ;
+  rdfs:range :SFRotation .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :OrientationDamper ;
+  rdfs:range :SFRotation .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:OrientationInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "OrientationInterpolator generates a series of 4-tuple axis-angle SFRotation values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :OrientationInterpolator ;
+  rdfs:range :MFRotation .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:OrthoViewpoint a owl:Class ;
+  rdfs:subClassOf :X3DViewpointNode ;
+  rdfs:label "OrthoViewpoint provides an orthographic perspective-free view of a scene from a specific location and direction." .
+:centerOfRotation a owl:DatatypeProperty ;
+  rdfs:domain :OrthoViewpoint ;
+  rdfs:range :SFVec3f .
+# description field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFString
+:fieldOfView a owl:DatatypeProperty ;
+  rdfs:domain :OrthoViewpoint ;
+  rdfs:range :MFFloat .
+# jump field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=true
+# orientation field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFRotation, default=0 0 1 0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :OrthoViewpoint ;
+  rdfs:range :SFVec3f .
+# retainUserOffsets field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=false
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PackagedShader a owl:Class ;
+  rdfs:subClassOf :X3DShaderNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:subClassOf :X3DProgrammableShaderObject ;
+  rdfs:label "PackagedShader can contain field declarations, but no CDATA section of plain-text source code." .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :PackagedShader ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentPackagedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentPackagedShader .
+# language field inheritedFrom=X3DShaderNode with accessType=initializeOnly, type=SFString, simpleType=shaderLanguageValues, baseType=xs:NMTOKEN
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+:hasIS a owl:ObjectProperty ;
+  rdfs:domain :PackagedShader ;
+  rdfs:range :IS ;
+  rdfs:subPropertyOf :hasChild .
+:fieldISHasParentPackagedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasIS ;
+  rdfs:subPropertyOf :hasParentPackagedShader .
+:hasMetadata a owl:ObjectProperty ;
+  rdfs:domain :PackagedShader ;
+  rdfs:range :X3DMetadataObject ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMetadataHasParentPackagedShader a owl:ObjectProperty ;
+  owl:inverseOf :hasMetadata ;
+  rdfs:subPropertyOf :hasParentPackagedShader .
+
+:ParticleSystem a owl:Class ;
+  rdfs:subClassOf :X3DShapeNode ;
+  rdfs:label "ParticleSystem specifies a complete particle system." .
+# appearance field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFNode, default=NULL
+# bboxCenter field inheritedFrom=X3DShapeNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DShapeNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:colorKey a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :MFFloat .
+:hasColorRamp a owl:ObjectProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorRampHasParentParticleSystem a owl:ObjectProperty ;
+  owl:inverseOf :hasColorRamp ;
+  rdfs:subPropertyOf :hasParentParticleSystem .
+:createParticles a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFBool .
+# displayBBox field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFBool, default=false
+:hasEmitter a owl:ObjectProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :X3DParticleEmitterNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldEmitterHasParentParticleSystem a owl:ObjectProperty ;
+  owl:inverseOf :hasEmitter ;
+  rdfs:subPropertyOf :hasParentParticleSystem .
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFBool .
+# geometry field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFNode, default=NULL
+:hasGeometry a owl:ObjectProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :X3DGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometryHasParentParticleSystem a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry ;
+  rdfs:subPropertyOf :hasParentParticleSystem .
+:geometryType a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :particleSystemGeometryTypeValues .
+:lifetimeVariation a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFFloat .
+:maxParticles a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFInt32 .
+:particleLifetime a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFFloat .
+:particleSize a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :SFVec2f .
+:hasPhysics a owl:ObjectProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :X3DParticlePhysicsModelNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldPhysicsHasParentParticleSystem a owl:ObjectProperty ;
+  owl:inverseOf :hasPhysics ;
+  rdfs:subPropertyOf :hasParentParticleSystem .
+:texCoordKey a owl:DatatypeProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :MFFloat .
+:hasTexCoordRamp a owl:ObjectProperty ;
+  rdfs:domain :ParticleSystem ;
+  rdfs:range :TextureCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTexCoordRampHasParentParticleSystem a owl:ObjectProperty ;
+  owl:inverseOf :hasTexCoordRamp ;
+  rdfs:subPropertyOf :hasParentParticleSystem .
+# visible field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PickableGroup a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:subClassOf :X3DPickableObject ;
+  rdfs:label "PickableGroup is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# objectType field inheritedFrom=X3DPickableObject with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickable field inheritedFrom=X3DPickableObject with accessType=inputOutput, type=SFBool, default=true
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PixelTexture a owl:Class ;
+  rdfs:subClassOf :X3DTexture2DNode ;
+  rdfs:label "PixelTexture creates a 2D-image texture map using a numeric array of pixel values." .
+:image a owl:DatatypeProperty ;
+  rdfs:domain :PixelTexture ;
+  rdfs:range :SFImage .
+# repeatS field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# repeatT field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFBool, default=true
+# textureProperties field inheritedFrom=X3DTexture2DNode with accessType=initializeOnly, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PixelTexture3D a owl:Class ;
+  rdfs:subClassOf :X3DTexture3DNode ;
+  rdfs:label "PixelTexture3D defines a 3D image-based texture map as an explicit array of pixel values (image field)." .
+:image a owl:DatatypeProperty ;
+  rdfs:domain :PixelTexture3D ;
+  rdfs:range :MFInt32 .
+# repeatR field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatS field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# repeatT field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFBool, default=false
+# textureProperties field inheritedFrom=X3DTexture3DNode with accessType=initializeOnly, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PlaneSensor a owl:Class ;
+  rdfs:subClassOf :X3DDragSensorNode ;
+  rdfs:label "PlaneSensor converts pointing device motion into 2D translation parallel to the local Z=0 plane." .
+# autoOffset field inheritedFrom=X3DDragSensorNode with accessType=inputOutput, type=SFBool, default=true
+:axisRotation a owl:DatatypeProperty ;
+  rdfs:domain :PlaneSensor ;
+  rdfs:range :SFRotation .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:maxPosition a owl:DatatypeProperty ;
+  rdfs:domain :PlaneSensor ;
+  rdfs:range :SFVec2f .
+:minPosition a owl:DatatypeProperty ;
+  rdfs:domain :PlaneSensor ;
+  rdfs:range :SFVec2f .
+:offset a owl:DatatypeProperty ;
+  rdfs:domain :PlaneSensor ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PointEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "PointEmitter generates particles from a specific point in space using the specified direction and speed." .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :PointEmitter ;
+  rdfs:range :SFVec3f .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :PointEmitter ;
+  rdfs:range :SFVec3f .
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PointLight a owl:Class ;
+  rdfs:subClassOf :X3DLightNode ;
+  rdfs:label "Linear attenuation may occur at level 2, full support at level 3." .
+# ambientIntensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=0, baseType=intensityType
+:attenuation a owl:DatatypeProperty ;
+  rdfs:domain :PointLight ;
+  rdfs:range :SFVec3f .
+# color field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFColor, default=1 1 1
+:global a owl:DatatypeProperty ;
+  rdfs:domain :PointLight ;
+  rdfs:range :SFBool .
+# intensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=1, baseType=intensityType
+:location a owl:DatatypeProperty ;
+  rdfs:domain :PointLight ;
+  rdfs:range :SFVec3f .
+# on field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFBool, default=true
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :PointLight ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PointPickSensor a owl:Class ;
+  rdfs:subClassOf :X3DPickSensorNode ;
+  rdfs:label "PointPickSensor tests one or more pickingGeometry points in space as lying inside the provided pickTarget geometry." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# intersectionType field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=BOUNDS, simpleType=intersectionTypeValues, baseType=xs:NMTOKEN
+# matchCriterion field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFString, default=MATCH_ANY, simpleType=pickSensorMatchCriterionChoices, baseType=xs:NMTOKEN
+# objectType field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickingGeometry field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFNode, default=NULL
+# pickTarget field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFNode
+# sortOrder field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=CLOSEST, simpleType=pickSensorSortOrderValues, baseType=xs:NMTOKEN
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PointProperties a owl:Class ;
+  rdfs:subClassOf :X3DAppearanceChildNode ;
+  rdfs:label "PointProperties allows precise fine-grained control over the rendering style of PointSet node points inside the same Shape." .
+:colorMode a owl:DatatypeProperty ;
+  rdfs:domain :PointProperties ;
+  rdfs:range :colorModeChoices .
+:pointSizeAttenuation a owl:DatatypeProperty ;
+  rdfs:domain :PointProperties ;
+  rdfs:range :MFFloat .
+:pointSizeMaxValue a owl:DatatypeProperty ;
+  rdfs:domain :PointProperties ;
+  rdfs:range :SFFloat .
+:pointSizeMinValue a owl:DatatypeProperty ;
+  rdfs:domain :PointProperties ;
+  rdfs:range :SFFloat .
+:pointSizeScaleFactor a owl:DatatypeProperty ;
+  rdfs:domain :PointProperties ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PointSet a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "PointSet is a node that contains a set of colored 3D points, represented by contained Color|ColorRGBA and Coordinate|CoordinateDouble nodes." .
+:hasAttrib a owl:ObjectProperty ;
+  rdfs:domain :PointSet ;
+  rdfs:range :X3DVertexAttributeNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldAttribHasParentPointSet a owl:ObjectProperty ;
+  owl:inverseOf :hasAttrib ;
+  rdfs:subPropertyOf :hasParentPointSet .
+:hasColor a owl:ObjectProperty ;
+  rdfs:domain :PointSet ;
+  rdfs:range :X3DColorNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColorHasParentPointSet a owl:ObjectProperty ;
+  owl:inverseOf :hasColor ;
+  rdfs:subPropertyOf :hasParentPointSet .
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :PointSet ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentPointSet a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentPointSet .
+:hasFogCoord a owl:ObjectProperty ;
+  rdfs:domain :PointSet ;
+  rdfs:range :FogCoordinate ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFogCoordHasParentPointSet a owl:ObjectProperty ;
+  owl:inverseOf :hasFogCoord ;
+  rdfs:subPropertyOf :hasParentPointSet .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Polyline2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Polyline2D is a geometry node that defines a connected set of vertices in a contiguous set of line segments in X-Y plane." .
+:lineSegments a owl:DatatypeProperty ;
+  rdfs:domain :Polyline2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PolylineEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "PolylineEmitter emits particles along a single polyline." .
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :PolylineEmitter ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentPolylineEmitter a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentPolylineEmitter .
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :PolylineEmitter ;
+  rdfs:range :MFInt32 .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :PolylineEmitter ;
+  rdfs:range :SFVec3f .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Polypoint2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Polypoint2D is a geometry node that defines a set of 2D points in X-Y plane." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :Polypoint2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionChaser a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "PositionChaser generates a series of position values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :PositionChaser ;
+  rdfs:range :SFVec3f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionChaser ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionChaser2D a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "PositionChaser2D generates a series of 2D position values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :PositionChaser2D ;
+  rdfs:range :SFVec2f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionChaser2D ;
+  rdfs:range :SFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionDamper a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "PositionDamper generates a series of position values that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :PositionDamper ;
+  rdfs:range :SFVec3f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionDamper ;
+  rdfs:range :SFVec3f .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionDamper2D a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "PositionDamper2D generates a series of 2D floating-point values that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :PositionDamper2D ;
+  rdfs:range :SFVec2f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionDamper2D ;
+  rdfs:range :SFVec2f .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "PositionInterpolator generates a series of 3-tuple SFVec3f values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionInterpolator ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PositionInterpolator2D a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "PositionInterpolator2D generates a series of SFVec2f values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :PositionInterpolator2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:PrimitivePickSensor a owl:Class ;
+  rdfs:subClassOf :X3DPickSensorNode ;
+  rdfs:label "If a non-uniform scale is applied to the pick sensor, correct results may require level 3 support." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# intersectionType field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=BOUNDS, simpleType=intersectionTypeValues, baseType=xs:NMTOKEN
+# matchCriterion field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFString, default=MATCH_ANY, simpleType=pickSensorMatchCriterionChoices, baseType=xs:NMTOKEN
+# objectType field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickingGeometry field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFNode, default=NULL
+# pickTarget field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFNode
+# sortOrder field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=CLOSEST, simpleType=pickSensorSortOrderValues, baseType=xs:NMTOKEN
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ProgramShader a owl:Class ;
+  rdfs:subClassOf :X3DShaderNode ;
+  rdfs:label "ProgramShader contains no field declarations and no plain-text source code." .
+# language field inheritedFrom=X3DShaderNode with accessType=initializeOnly, type=SFString, simpleType=shaderLanguageValues, baseType=xs:NMTOKEN
+:hasPrograms a owl:ObjectProperty ;
+  rdfs:domain :ProgramShader ;
+  rdfs:range :ShaderProgram ;
+  rdfs:subPropertyOf :hasChild .
+:fieldProgramsHasParentProgramShader a owl:ObjectProperty ;
+  owl:inverseOf :hasPrograms ;
+  rdfs:subPropertyOf :hasParentProgramShader .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ProjectionVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DVolumeRenderStyleNode ;
+  rdfs:label "ProjectionVolumeStyle uses voxel data to directly generate output color." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:intensityThreshold a owl:DatatypeProperty ;
+  rdfs:domain :ProjectionVolumeStyle ;
+  rdfs:range :SFFloat .
+:type a owl:DatatypeProperty ;
+  rdfs:domain :ProjectionVolumeStyle ;
+  rdfs:range :projectionVolumeStyleTypeChoices .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ProtoInstance a owl:Class ;
+  rdfs:subClassOf :X3DPrototypeInstance ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "ProtoInstance can override field default values via fieldValue initializations. Non-recursive nested ProtoInstance and ProtoDeclare statements are allowed within a ProtoDeclare." .
+:hasFieldValue a owl:ObjectProperty ;
+  rdfs:domain :ProtoInstance ;
+  rdfs:range :fieldValue ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldValueHasParentProtoInstance a owl:ObjectProperty ;
+  owl:inverseOf :hasFieldValue ;
+  rdfs:subPropertyOf :hasParentProtoInstance .
+:name a owl:DatatypeProperty ;
+  rdfs:domain :ProtoInstance ;
+  rdfs:range xs:NMTOKEN .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ProximitySensor a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentalSensorNode ;
+  rdfs:label "ProximitySensor generates events when the viewer enters, exits and moves within a region of space (defined by a box)." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :ProximitySensor ;
+  rdfs:range :SFVec3f .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# size field inheritedFrom=X3DEnvironmentalSensorNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:QuadSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "QuadSet is a geometry node that defines quadrilaterals." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ReceiverPdu a owl:Class ;
+  rdfs:subClassOf :X3DNetworkSensorNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "ReceiverPdu is a networked Protocol Data Unit (PDU) information node that transmits the state of radio frequency (RF) receivers modeled in a simulation." .
+:address a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFString .
+:applicationID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:entityID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFVec3d .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :geoSystemType .
+:multicastRelayHost a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFString .
+:multicastRelayPort a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:networkMode a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :networkModeChoices .
+:port a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:radioID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:readInterval a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFTime .
+:receivedPower a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFFloat .
+:receiverState a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:rtpHeaderExpected a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFBool .
+:siteID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:transmitterApplicationID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:transmitterEntityID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:transmitterRadioID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:transmitterSiteID a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+:whichGeometry a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFInt32 .
+:writeInterval a owl:DatatypeProperty ;
+  rdfs:domain :ReceiverPdu ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Rectangle2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Rectangle2D is a geometry node that defines a 2D rectangle in X-Y plane." .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :Rectangle2D ;
+  rdfs:range :SFVec2f .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Rectangle2D ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:RigidBody a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "RigidBody describes a collection of shapes with a mass distribution that is affected by the physics model." .
+:angularDampingFactor a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFFloat .
+:angularVelocity a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFVec3f .
+:autoDamp a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+:autoDisable a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+:centerOfMass a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFVec3f .
+:disableAngularSpeed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFFloat .
+:disableLinearSpeed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFFloat .
+:disableTime a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFTime .
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+:finiteRotationAxis a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFVec3f .
+:fixed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+:forces a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :MFVec3f .
+:hasGeometry a owl:ObjectProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :X3DNBodyCollidableNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldGeometryHasParentRigidBody a owl:ObjectProperty ;
+  owl:inverseOf :hasGeometry ;
+  rdfs:subPropertyOf :hasParentRigidBody .
+:inertia a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFMatrix3f .
+:linearDampingFactor a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFFloat .
+:linearVelocity a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFVec3f .
+:mass a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFFloat .
+:hasMassDensityModel a owl:ObjectProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range  [ owl:unionOf (:Sphere :Box :Cone) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMassDensityModelHasParentRigidBody a owl:ObjectProperty ;
+  owl:inverseOf :hasMassDensityModel ;
+  rdfs:subPropertyOf :hasParentRigidBody .
+:orientation a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFRotation .
+:position a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFVec3f .
+:torques a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :MFVec3f .
+:useFiniteRotation a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+:useGlobalGravity a owl:DatatypeProperty ;
+  rdfs:domain :RigidBody ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:RigidBodyCollection a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "RigidBodyCollection represents a system of bodies that interact within a single physics model." .
+:autoDisable a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFBool .
+:hasBodies a owl:ObjectProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :RigidBody ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBodiesHasParentRigidBodyCollection a owl:ObjectProperty ;
+  owl:inverseOf :hasBodies ;
+  rdfs:subPropertyOf :hasParentRigidBodyCollection .
+:hasCollider a owl:ObjectProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :CollisionCollection ;
+  rdfs:subPropertyOf :hasChild .
+:fieldColliderHasParentRigidBodyCollection a owl:ObjectProperty ;
+  owl:inverseOf :hasCollider ;
+  rdfs:subPropertyOf :hasParentRigidBodyCollection .
+:constantForceMix a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:contactSurfaceThickness a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:disableAngularSpeed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:disableLinearSpeed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:disableTime a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFTime .
+:enabled a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFBool .
+:errorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:gravity a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFVec3f .
+:iterations a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFInt32 .
+:hasJoints a owl:ObjectProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :X3DRigidJointNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldJointsHasParentRigidBodyCollection a owl:ObjectProperty ;
+  owl:inverseOf :hasJoints ;
+  rdfs:subPropertyOf :hasParentRigidBodyCollection .
+:maxCorrectionSpeed a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFFloat .
+:preferAccuracy a owl:DatatypeProperty ;
+  rdfs:domain :RigidBodyCollection ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ScalarChaser a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "ScalarChaser generates a series of single floating-point values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :ScalarChaser ;
+  rdfs:range :SFFloat .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :ScalarChaser ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ScalarDamper a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "ScalarDamper generates a series of floating-point values that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :ScalarDamper ;
+  rdfs:range :SFFloat .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :ScalarDamper ;
+  rdfs:range :SFFloat .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ScalarInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "ScalarInterpolator generates piecewise-linear SFFloat values." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :ScalarInterpolator ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ScreenFontStyle a owl:Class ;
+  rdfs:subClassOf :X3DFontStyleNode ;
+  rdfs:label "ScreenFontStyle is an X3DFontStyleNode defines the size, family, justification, and other styles used within a screen layout." .
+:family a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :fontFamilyValues .
+:horizontal a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFBool .
+:justify a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :justifyChoices .
+:language a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFString .
+:leftToRight a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFBool .
+:pointSize a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFFloat .
+:spacing a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFFloat .
+:style a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :fontStyleChoices .
+:topToBottom a owl:DatatypeProperty ;
+  rdfs:domain :ScreenFontStyle ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ScreenGroup a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "ScreenGroup is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Script a owl:Class ;
+  rdfs:subClassOf :X3DScriptNode ;
+  rdfs:label "Script contains author-programmed event behaviors for a scene." .
+:directOutput a owl:DatatypeProperty ;
+  rdfs:domain :Script ;
+  rdfs:range :SFBool .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :Script ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentScript a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentScript .
+:mustEvaluate a owl:DatatypeProperty ;
+  rdfs:domain :Script ;
+  rdfs:range :SFBool .
+# url field inheritedFrom=X3DScriptNode with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SegmentedVolumeData a owl:Class ;
+  rdfs:subClassOf :X3DVolumeDataNode ;
+  rdfs:label "SegmentedVolumeData displays a segmented voxel dataset with different RenderStyle nodes." .
+# bboxCenter field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# dimensions field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFVec3f, default=1 1 1
+# displayBBox field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=false
+:hasRenderStyle a owl:ObjectProperty ;
+  rdfs:domain :SegmentedVolumeData ;
+  rdfs:range :X3DVolumeRenderStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRenderStyleHasParentSegmentedVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasRenderStyle ;
+  rdfs:subPropertyOf :hasParentSegmentedVolumeData .
+:segmentEnabled a owl:DatatypeProperty ;
+  rdfs:domain :SegmentedVolumeData ;
+  rdfs:range :MFBool .
+:hasSegmentIdentifiers a owl:ObjectProperty ;
+  rdfs:domain :SegmentedVolumeData ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSegmentIdentifiersHasParentSegmentedVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasSegmentIdentifiers ;
+  rdfs:subPropertyOf :hasParentSegmentedVolumeData .
+# visible field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=true
+:hasVoxels a owl:ObjectProperty ;
+  rdfs:domain :SegmentedVolumeData ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldVoxelsHasParentSegmentedVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasVoxels ;
+  rdfs:subPropertyOf :hasParentSegmentedVolumeData .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ShadedVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "All fields fully supported except shadows supported with at least Phong shading at level 3. All fields fully supported with at least Phong shading and Henyey-Greenstein phase function, shadows fully supported at level 4." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:lighting a owl:DatatypeProperty ;
+  rdfs:domain :ShadedVolumeStyle ;
+  rdfs:range :SFBool .
+:hasMaterial a owl:ObjectProperty ;
+  rdfs:domain :ShadedVolumeStyle ;
+  rdfs:range :X3DMaterialNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldMaterialHasParentShadedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasMaterial ;
+  rdfs:subPropertyOf :hasParentShadedVolumeStyle .
+:phaseFunction a owl:DatatypeProperty ;
+  rdfs:domain :ShadedVolumeStyle ;
+  rdfs:range :phaseFunctionValues .
+:shadows a owl:DatatypeProperty ;
+  rdfs:domain :ShadedVolumeStyle ;
+  rdfs:range :SFBool .
+:hasSurfaceNormals a owl:ObjectProperty ;
+  rdfs:domain :ShadedVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceNormalsHasParentShadedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasSurfaceNormals ;
+  rdfs:subPropertyOf :hasParentShadedVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ShaderPart a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:label "ShaderPart can contain a CDATA section of plain-text source code." .
+:type a owl:DatatypeProperty ;
+  rdfs:domain :ShaderPart ;
+  rdfs:range :shaderPartTypeValues .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ShaderProgram a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:subClassOf :X3DUrlObject ;
+  rdfs:subClassOf :X3DProgrammableShaderObject ;
+  rdfs:label "ShaderProgram can contain field declarations and a CDATA section of plain-text source code." .
+:hasField a owl:ObjectProperty ;
+  rdfs:domain :ShaderProgram ;
+  rdfs:range :field ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFieldHasParentShaderProgram a owl:ObjectProperty ;
+  owl:inverseOf :hasField ;
+  rdfs:subPropertyOf :hasParentShaderProgram .
+:type a owl:DatatypeProperty ;
+  rdfs:domain :ShaderProgram ;
+  rdfs:range :shaderPartTypeValues .
+# url field inheritedFrom=X3DUrlObject with accessType=inputOutput, type=MFString
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Shape a owl:Class ;
+  rdfs:subClassOf :X3DShapeNode ;
+  rdfs:label "Shape can appear under any grouping node." .
+# appearance field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFNode, default=NULL
+# bboxCenter field inheritedFrom=X3DShapeNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DShapeNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# displayBBox field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFBool, default=false
+# geometry field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFNode, default=NULL
+# visible field inheritedFrom=X3DShapeNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SignalPdu a owl:Class ;
+  rdfs:subClassOf :X3DNetworkSensorNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "SignalPdu is a networked Protocol Data Unit (PDU) information node that communicates the transmission of voice, audio or other data modeled in a simulation." .
+:address a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFString .
+:applicationID a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:data a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :MFInt32 .
+:dataLength a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:encodingScheme a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:entityID a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFVec3d .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :geoSystemType .
+:multicastRelayHost a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFString .
+:multicastRelayPort a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:networkMode a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :networkModeChoices .
+:port a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:radioID a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:readInterval a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFTime .
+:rtpHeaderExpected a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFBool .
+:sampleRate a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:samples a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:siteID a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:tdlType a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+:whichGeometry a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFInt32 .
+:writeInterval a owl:DatatypeProperty ;
+  rdfs:domain :SignalPdu ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SilhouetteEnhancementVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "SilhouetteEnhancementVolumeStyle specifies that volumetric data is rendered with silhouette enhancement." .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:silhouetteBoundaryOpacity a owl:DatatypeProperty ;
+  rdfs:domain :SilhouetteEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+:silhouetteRetainedOpacity a owl:DatatypeProperty ;
+  rdfs:domain :SilhouetteEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+:silhouetteSharpness a owl:DatatypeProperty ;
+  rdfs:domain :SilhouetteEnhancementVolumeStyle ;
+  rdfs:range :SFFloat .
+:hasSurfaceNormals a owl:ObjectProperty ;
+  rdfs:domain :SilhouetteEnhancementVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceNormalsHasParentSilhouetteEnhancementVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasSurfaceNormals ;
+  rdfs:subPropertyOf :hasParentSilhouetteEnhancementVolumeStyle .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SingleAxisHingeJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "SingleAxisHingeJoint has single axis about which to rotate, similar to a traditional door hinge. Contains two RigidBody nodes (containerField values body1, body2)." .
+:anchorPoint a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFVec3f .
+:axis a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFVec3f .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+:maxAngle a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:minAngle a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:stopBounce a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+:stopErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :SingleAxisHingeJoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SliderJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "SliderJoint constrains all movement between body1 and body2 along a single axis. Contains two RigidBody nodes (containerField values body1, body2)." .
+:axis a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFVec3f .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+:maxSeparation a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFFloat .
+:minSeparation a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFFloat .
+:sliderForce a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFFloat .
+:stopBounce a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFFloat .
+:stopErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :SliderJoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Sound a owl:Class ;
+  rdfs:subClassOf :X3DSoundNode ;
+  rdfs:label "The Sound node controls the 3D spatialization of sound playback by a child AudioClip or MovieTexture node." .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFVec3f .
+:intensity a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :intensityType .
+:location a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFVec3f .
+:maxBack a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFFloat .
+:maxFront a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFFloat .
+:minBack a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFFloat .
+:minFront a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFFloat .
+:priority a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :intensityType .
+:hasSource a owl:ObjectProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :X3DSoundSourceNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSourceHasParentSound a owl:ObjectProperty ;
+  owl:inverseOf :hasSource ;
+  rdfs:subPropertyOf :hasParentSound .
+:spatialize a owl:DatatypeProperty ;
+  rdfs:domain :Sound ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Sphere a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Sphere is a geometry node, representing a perfectly round geometrical object that is the surface of a completely round ball." .
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :Sphere ;
+  rdfs:range :SFFloat .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Sphere ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SphereSensor a owl:Class ;
+  rdfs:subClassOf :X3DDragSensorNode ;
+  rdfs:label "SphereSensor converts pointing device motion into a spherical rotation about the origin of the local coordinate system." .
+# autoOffset field inheritedFrom=X3DDragSensorNode with accessType=inputOutput, type=SFBool, default=true
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:offset a owl:DatatypeProperty ;
+  rdfs:domain :SphereSensor ;
+  rdfs:range :SFRotation .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SplinePositionInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "SplinePositionInterpolator performs non-linear interpolation among paired lists of 3-tuple values and velocities to produce an SFVec3f value_changed output event." .
+:closed a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator ;
+  rdfs:range :SFBool .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator ;
+  rdfs:range :MFVec3f .
+:keyVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator ;
+  rdfs:range :MFVec3f .
+:normalizeVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SplinePositionInterpolator2D a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "SplinePositionInterpolator2D performs non-linear interpolation among paired lists of 2-tuple values and velocities to produce an SFVec2f value_changed output event." .
+:closed a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator2D ;
+  rdfs:range :SFBool .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator2D ;
+  rdfs:range :MFVec2f .
+:keyVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator2D ;
+  rdfs:range :MFVec2f .
+:normalizeVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplinePositionInterpolator2D ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SplineScalarInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "SplineScalarInterpolator performs non-linear interpolation among paired lists of float values and velocities to produce an SFFloat value_changed output event." .
+:closed a owl:DatatypeProperty ;
+  rdfs:domain :SplineScalarInterpolator ;
+  rdfs:range :SFBool .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :SplineScalarInterpolator ;
+  rdfs:range :MFFloat .
+:keyVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplineScalarInterpolator ;
+  rdfs:range :MFFloat .
+:normalizeVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SplineScalarInterpolator ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SpotLight a owl:Class ;
+  rdfs:subClassOf :X3DLightNode ;
+  rdfs:label "Linear attenuation may occur at level 2, full support at level 3." .
+# ambientIntensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=0, baseType=intensityType
+:attenuation a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFVec3f .
+:beamWidth a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFFloat .
+# color field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFColor, default=1 1 1
+:cutOffAngle a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFFloat .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFVec3f .
+:global a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFBool .
+# intensity field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFFloat, default=1, baseType=intensityType
+:location a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFVec3f .
+# on field inheritedFrom=X3DLightNode with accessType=inputOutput, type=SFBool, default=true
+:radius a owl:DatatypeProperty ;
+  rdfs:domain :SpotLight ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SquadOrientationInterpolator a owl:Class ;
+  rdfs:subClassOf :X3DInterpolatorNode ;
+  rdfs:label "SquadOrientationInterpolator performs non-linear interpolation among paired lists of rotation values to produce an SFRotation value_changed output event." .
+# key field inheritedFrom=X3DInterpolatorNode with accessType=inputOutput, type=MFFloat
+:keyValue a owl:DatatypeProperty ;
+  rdfs:domain :SquadOrientationInterpolator ;
+  rdfs:range :MFRotation .
+:normalizeVelocity a owl:DatatypeProperty ;
+  rdfs:domain :SquadOrientationInterpolator ;
+  rdfs:range :SFBool .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:StaticGroup a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "StaticGroup is similar to Group node but does not allow access to children after creation time." .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :StaticGroup ;
+  rdfs:range :X3DChildNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentStaticGroup .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:StringSensor a owl:Class ;
+  rdfs:subClassOf :X3DKeyDeviceSensorNode ;
+  rdfs:label "StringSensor generates events as the user presses keys on the keyboard." .
+:deletionAllowed a owl:DatatypeProperty ;
+  rdfs:domain :StringSensor ;
+  rdfs:range :SFBool .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:SurfaceEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "SurfaceEmitter generates particles from the surface of an object." .
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :SurfaceEmitter ;
+  rdfs:range :MFInt32 .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+:hasSurface a owl:ObjectProperty ;
+  rdfs:domain :SurfaceEmitter ;
+  rdfs:range :X3DGeometryNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceHasParentSurfaceEmitter a owl:ObjectProperty ;
+  owl:inverseOf :hasSurface ;
+  rdfs:subPropertyOf :hasParentSurfaceEmitter .
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Switch a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "Switch is a Grouping node that only renders one (or zero) child at a time." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+:whichChoice a owl:DatatypeProperty ;
+  rdfs:domain :Switch ;
+  rdfs:range :SFInt32 .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TexCoordChaser2D a owl:Class ;
+  rdfs:subClassOf :X3DChaserNode ;
+  rdfs:label "TexCoordChaser2D generates a series of single floating-point values that progressively change from initial value to destination value." .
+# duration field inheritedFrom=X3DChaserNode with accessType=initializeOnly, type=SFTime, default=1
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :TexCoordChaser2D ;
+  rdfs:range :MFVec2f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :TexCoordChaser2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TexCoordDamper2D a owl:Class ;
+  rdfs:subClassOf :X3DDamperNode ;
+  rdfs:label "TexCoordDamper2D generates a series of 2D floating-point arrays that progressively change from initial value to destination value." .
+:initialDestination a owl:DatatypeProperty ;
+  rdfs:domain :TexCoordDamper2D ;
+  rdfs:range :MFVec2f .
+:initialValue a owl:DatatypeProperty ;
+  rdfs:domain :TexCoordDamper2D ;
+  rdfs:range :MFVec2f .
+# order field inheritedFrom=X3DDamperNode with accessType=initializeOnly, type=SFInt32, default=3
+# tau field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFTime, default=0.3
+# tolerance field inheritedFrom=X3DDamperNode with accessType=inputOutput, type=SFFloat, default=-1
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Text a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "Text is a 2D (flat) geometry node that can contain multiple lines of string values." .
+:hasFontStyle a owl:ObjectProperty ;
+  rdfs:domain :Text ;
+  rdfs:range :X3DFontStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFontStyleHasParentText a owl:ObjectProperty ;
+  owl:inverseOf :hasFontStyle ;
+  rdfs:subPropertyOf :hasParentText .
+:length a owl:DatatypeProperty ;
+  rdfs:domain :Text ;
+  rdfs:range :MFFloat .
+:maxExtent a owl:DatatypeProperty ;
+  rdfs:domain :Text ;
+  rdfs:range :SFFloat .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :Text ;
+  rdfs:range :SFBool .
+:string a owl:DatatypeProperty ;
+  rdfs:domain :Text ;
+  rdfs:range :MFString .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureBackground a owl:Class ;
+  rdfs:subClassOf :X3DBackgroundNode ;
+  rdfs:label "TextureBackground simulates ground and sky, using vertical arrays of wraparound color values, TextureBackground can also provide backdrop texture images on all six sides." .
+:hasBackTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBackTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasBackTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+:hasBottomTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldBottomTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasBottomTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+:hasFrontTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldFrontTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasFrontTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+# groundAngle field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFFloat
+# groundColor field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFColor
+:hasLeftTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldLeftTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasLeftTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+:hasRightTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRightTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasRightTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+# skyAngle field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFFloat
+# skyColor field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=MFColor, default=0 0 0
+:hasTopTexture a owl:ObjectProperty ;
+  rdfs:domain :TextureBackground ;
+  rdfs:range  [ owl:unionOf (:X3DTexture2DNode :MultiTexture) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTopTextureHasParentTextureBackground a owl:ObjectProperty ;
+  owl:inverseOf :hasTopTexture ;
+  rdfs:subPropertyOf :hasParentTextureBackground .
+# transparency field inheritedFrom=X3DBackgroundNode with accessType=inputOutput, type=SFFloat, default=0, baseType=intensityType
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureCoordinate a owl:Class ;
+  rdfs:subClassOf :X3DTextureCoordinateNode ;
+  rdfs:label "TextureCoordinate specifies 2D (s,t) texture-coordinate points, used by vertex-based geometry nodes (such as IndexedFaceSet or ElevationGrid) to map textures to vertices (and patches to NURBS surfaces)." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :TextureCoordinate ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureCoordinate3D a owl:Class ;
+  rdfs:subClassOf :X3DTextureCoordinateNode ;
+  rdfs:label "TextureCoordinate3D specifies a set of 3D texture coordinates used by vertex-based geometry nodes (such as IndexedFaceSet or ElevationGrid) to map 3D textures to vertices." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :TextureCoordinate3D ;
+  rdfs:range :MFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureCoordinate4D a owl:Class ;
+  rdfs:subClassOf :X3DTextureCoordinateNode ;
+  rdfs:label "TextureCoordinate4D specifies a set of 4D (homogeneous 3D) texture coordinates used by vertex-based geometry nodes (such as IndexedFaceSet or ElevationGrid) to map 3D textures to vertices." .
+:point a owl:DatatypeProperty ;
+  rdfs:domain :TextureCoordinate4D ;
+  rdfs:range :MFVec4f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureCoordinateGenerator a owl:Class ;
+  rdfs:subClassOf :X3DTextureCoordinateNode ;
+  rdfs:label "TextureCoordinateGenerator computes 2D (s,t) texture-coordinate points, used by vertex-based geometry nodes (such as IndexedFaceSet or ElevationGrid) to map textures to vertices (and patches to NURBS surfaces)." .
+:mode a owl:DatatypeProperty ;
+  rdfs:domain :TextureCoordinateGenerator ;
+  rdfs:range :textureCoordinateGeneratorModeChoices .
+:parameter a owl:DatatypeProperty ;
+  rdfs:domain :TextureCoordinateGenerator ;
+  rdfs:range :MFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureProperties a owl:Class ;
+  rdfs:subClassOf :X3DNode ;
+  rdfs:label "TextureProperties allows precise fine-grained control over application of image textures to geometry." .
+:anisotropicDegree a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :SFFloat .
+:borderColor a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :SFColorRGBA .
+:borderWidth a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :SFInt32 .
+:boundaryModeR a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureBoundaryModeChoices .
+:boundaryModeS a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureBoundaryModeChoices .
+:boundaryModeT a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureBoundaryModeChoices .
+:generateMipMaps a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :SFBool .
+:magnificationFilter a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureMagnificationModeChoices .
+:minificationFilter a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureMinificationModeChoices .
+:textureCompression a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :textureCompressionModeChoices .
+:texturePriority a owl:DatatypeProperty ;
+  rdfs:domain :TextureProperties ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureTransform a owl:Class ;
+  rdfs:subClassOf :X3DTextureTransformNode ;
+  rdfs:label "TextureTransform shifts 2D texture coordinates for positioning, orienting and scaling image textures on geometry." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform ;
+  rdfs:range :SFVec2f .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform ;
+  rdfs:range :SFFloat .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform ;
+  rdfs:range :SFVec2f .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform ;
+  rdfs:range :SFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureTransform3D a owl:Class ;
+  rdfs:subClassOf :X3DTextureTransformNode ;
+  rdfs:label "TextureTransform3D applies a 3D transformation to texture coordinates." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform3D ;
+  rdfs:range :SFVec3f .
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform3D ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform3D ;
+  rdfs:range :SFVec3f .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransform3D ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TextureTransformMatrix3D a owl:Class ;
+  rdfs:subClassOf :X3DTextureTransformNode ;
+  rdfs:label "TextureTransformMatrix3D applies a 3D transformation to texture coordinates." .
+:matrix a owl:DatatypeProperty ;
+  rdfs:domain :TextureTransformMatrix3D ;
+  rdfs:range :SFMatrix4f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TimeSensor a owl:Class ;
+  rdfs:subClassOf :X3DTimeDependentNode ;
+  rdfs:subClassOf :X3DSensorNode ;
+  rdfs:label "TimeSensor continuously generates events as time passes." .
+:cycleInterval a owl:DatatypeProperty ;
+  rdfs:domain :TimeSensor ;
+  rdfs:range :SFTime .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# loop field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFBool, default=false
+# pauseTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# resumeTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# startTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# stopTime field inheritedFrom=X3DTimeDependentNode with accessType=inputOutput, type=SFTime, default=0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TimeTrigger a owl:Class ;
+  rdfs:subClassOf :X3DTriggerNode ;
+  rdfs:label "TimeTrigger converts boolean true events to time events." .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ToneMappedVolumeStyle a owl:Class ;
+  rdfs:subClassOf :X3DComposableVolumeRenderStyleNode ;
+  rdfs:label "ToneMappedVolumeStyle specifies that volumetric data is rendered with Gooch shading model of two-toned warm/cool coloring." .
+:coolColor a owl:DatatypeProperty ;
+  rdfs:domain :ToneMappedVolumeStyle ;
+  rdfs:range :SFColorRGBA .
+# enabled field inheritedFrom=X3DVolumeRenderStyleNode with accessType=inputOutput, type=SFBool, default=true
+:hasSurfaceNormals a owl:ObjectProperty ;
+  rdfs:domain :ToneMappedVolumeStyle ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldSurfaceNormalsHasParentToneMappedVolumeStyle a owl:ObjectProperty ;
+  owl:inverseOf :hasSurfaceNormals ;
+  rdfs:subPropertyOf :hasParentToneMappedVolumeStyle .
+:warmColor a owl:DatatypeProperty ;
+  rdfs:domain :ToneMappedVolumeStyle ;
+  rdfs:range :SFColorRGBA .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TouchSensor a owl:Class ;
+  rdfs:subClassOf :X3DTouchSensorNode ;
+  rdfs:label "TouchSensor tracks location and state of the pointing device, detecting when a user points at or selects (activates) geometry." .
+# description field inheritedFrom=X3DPointingDeviceSensorNode with accessType=inputOutput, type=SFString
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Transform a owl:Class ;
+  rdfs:subClassOf :X3DGroupingNode ;
+  rdfs:label "Transform is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:center a owl:DatatypeProperty ;
+  rdfs:domain :Transform ;
+  rdfs:range :SFVec3f .
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+:rotation a owl:DatatypeProperty ;
+  rdfs:domain :Transform ;
+  rdfs:range :SFRotation .
+:scale a owl:DatatypeProperty ;
+  rdfs:domain :Transform ;
+  rdfs:range :SFVec3f .
+:scaleOrientation a owl:DatatypeProperty ;
+  rdfs:domain :Transform ;
+  rdfs:range :SFRotation .
+:translation a owl:DatatypeProperty ;
+  rdfs:domain :Transform ;
+  rdfs:range :SFVec3f .
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TransformSensor a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentalSensorNode ;
+  rdfs:label "TransformSensor generates output events when its targetObject enters, exits, and moves within a region in space (defined by a box)." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :TransformSensor ;
+  rdfs:range :SFVec3f .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# size field inheritedFrom=X3DEnvironmentalSensorNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+:hasTargetObject a owl:ObjectProperty ;
+  rdfs:domain :TransformSensor ;
+  rdfs:range  [ owl:unionOf (:X3DGroupingNode :X3DShapeNode) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldTargetObjectHasParentTransformSensor a owl:ObjectProperty ;
+  owl:inverseOf :hasTargetObject ;
+  rdfs:subPropertyOf :hasParentTransformSensor .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TransmitterPdu a owl:Class ;
+  rdfs:subClassOf :X3DNetworkSensorNode ;
+  rdfs:subClassOf :X3DBoundedObject ;
+  rdfs:label "TransmitterPdu is a networked Protocol Data Unit (PDU) information node that provides detailed information about a radio transmitter modeled in a simulation." .
+:address a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFString .
+:antennaLocation a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFVec3f .
+:antennaPatternLength a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:antennaPatternType a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:applicationID a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+# bboxCenter field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DBoundedObject with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+:cryptoKeyID a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:cryptoSystem a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+# displayBBox field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=false
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+:entityID a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:frequency a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:geoCoords a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFVec3d .
+:geoSystem a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :geoSystemType .
+:inputSource a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:lengthOfModulationParameters a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:modulationTypeDetail a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:modulationTypeMajor a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:modulationTypeSpreadSpectrum a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:modulationTypeSystem a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:multicastRelayHost a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFString .
+:multicastRelayPort a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:networkMode a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :networkModeChoices .
+:port a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:power a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFFloat .
+:radioEntityTypeCategory a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioEntityTypeCountry a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioEntityTypeDomain a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioEntityTypeKind a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioEntityTypeNomenclature a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioEntityTypeNomenclatureVersion a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:radioID a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:readInterval a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFTime .
+:relativeAntennaLocation a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFVec3f .
+:rtpHeaderExpected a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFBool .
+:siteID a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:transmitFrequencyBandwidth a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFFloat .
+:transmitState a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+# visible field inheritedFrom=X3DBoundedObject with accessType=inputOutput, type=SFBool, default=true
+:whichGeometry a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFInt32 .
+:writeInterval a owl:DatatypeProperty ;
+  rdfs:domain :TransmitterPdu ;
+  rdfs:range :SFTime .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TriangleFanSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "TriangleFanSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+:fanCount a owl:DatatypeProperty ;
+  rdfs:domain :TriangleFanSet ;
+  rdfs:range :MFInt32 .
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TriangleSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "TriangleSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TriangleSet2D a owl:Class ;
+  rdfs:subClassOf :X3DGeometryNode ;
+  rdfs:label "TriangleSet2D is a geometry node that defines a set of filled 2D triangles in X-Y plane." .
+:solid a owl:DatatypeProperty ;
+  rdfs:domain :TriangleSet2D ;
+  rdfs:range :SFBool .
+:vertices a owl:DatatypeProperty ;
+  rdfs:domain :TriangleSet2D ;
+  rdfs:range :MFVec2f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TriangleStripSet a owl:Class ;
+  rdfs:subClassOf :X3DComposedGeometryNode ;
+  rdfs:label "TriangleStripSet is a geometry node containing a Coordinate|CoordinateDouble node, and can also contain Color|ColorRGBA, Normal and TextureCoordinate nodes." .
+# attrib field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=MFNode
+# ccw field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# color field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# colorPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# coord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# fogCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normal field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# normalPerVertex field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+# solid field inheritedFrom=X3DComposedGeometryNode with accessType=initializeOnly, type=SFBool, default=true
+:stripCount a owl:DatatypeProperty ;
+  rdfs:domain :TriangleStripSet ;
+  rdfs:range :MFInt32 .
+# texCoord field inheritedFrom=X3DComposedGeometryNode with accessType=inputOutput, type=SFNode, default=NULL
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:TwoSidedMaterial a owl:Class ;
+  rdfs:subClassOf :X3DMaterialNode ;
+  rdfs:label "TwoSidedMaterial specifies surface rendering properties for associated geometry nodes, for outer (front) and inner (back) sides of polygons." .
+:ambientIntensity a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+:backAmbientIntensity a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+:backDiffuseColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:backEmissiveColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:backShininess a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+:backSpecularColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:backTransparency a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+:diffuseColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:emissiveColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:separateBackColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFBool .
+:shininess a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+:specularColor a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :SFColor .
+:transparency a owl:DatatypeProperty ;
+  rdfs:domain :TwoSidedMaterial ;
+  rdfs:range :intensityType .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:UniversalJoint a owl:Class ;
+  rdfs:subClassOf :X3DRigidJointNode ;
+  rdfs:label "UniversalJoint is like a BallJoint that constrains an extra degree of rotational freedom." .
+:anchorPoint a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFVec3f .
+:axis1 a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFVec3f .
+:axis2 a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFVec3f .
+# body1 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# body2 field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=SFNode, default=NULL
+# forceOutput field inheritedFrom=X3DRigidJointNode with accessType=inputOutput, type=MFString, default="NONE", simpleType=forceOutputValues, baseType=MFString
+:stop1Bounce a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFFloat .
+:stop1ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFFloat .
+:stop2Bounce a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFFloat .
+:stop2ErrorCorrection a owl:DatatypeProperty ;
+  rdfs:domain :UniversalJoint ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Viewpoint a owl:Class ;
+  rdfs:subClassOf :X3DViewpointNode ;
+  rdfs:label "Viewpoint provides a specific location and direction where the user may view the scene." .
+:centerOfRotation a owl:DatatypeProperty ;
+  rdfs:domain :Viewpoint ;
+  rdfs:range :SFVec3f .
+# description field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFString
+:fieldOfView a owl:DatatypeProperty ;
+  rdfs:domain :Viewpoint ;
+  rdfs:range :SFFloat .
+# jump field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=true
+# orientation field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFRotation, default=0 0 1 0
+:position a owl:DatatypeProperty ;
+  rdfs:domain :Viewpoint ;
+  rdfs:range :SFVec3f .
+# retainUserOffsets field inheritedFrom=X3DViewpointNode with accessType=inputOutput, type=SFBool, default=false
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:ViewpointGroup a owl:Class ;
+  rdfs:subClassOf :X3DChildNode ;
+  rdfs:label "ViewpointGroup can contain Viewpoint, OrthoViewpoint, GeoViewpoint and other ViewpointGroup nodes for better user-navigation support with a shared description on the viewpoint list." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range :SFVec3f .
+:hasChildren a owl:ObjectProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range  [ owl:unionOf (:X3DViewpointNode :ViewpointGroup) ] ;
+  rdfs:subPropertyOf :hasChild .
+:fieldChildrenHasParent a owl:ObjectProperty ;
+  owl:inverseOf :hasChildren ;
+  rdfs:subPropertyOf :hasParentViewpointGroup .
+:description a owl:DatatypeProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range :SFString .
+:displayed a owl:DatatypeProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range :SFBool .
+:retainUserOffsets a owl:DatatypeProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range :SFBool .
+:size a owl:DatatypeProperty ;
+  rdfs:domain :ViewpointGroup ;
+  rdfs:range :SFVec3f .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:Viewport a owl:Class ;
+  rdfs:subClassOf :X3DViewportNode ;
+  rdfs:label "Viewport is a Grouping node that can contain most nodes." .
+# bboxCenter field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DGroupingNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# children field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=MFNode
+:clipBoundary a owl:DatatypeProperty ;
+  rdfs:domain :Viewport ;
+  rdfs:range :MFFloat .
+# displayBBox field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=false
+# visible field inheritedFrom=X3DGroupingNode with accessType=inputOutput, type=SFBool, default=true
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:VisibilitySensor a owl:Class ;
+  rdfs:subClassOf :X3DEnvironmentalSensorNode ;
+  rdfs:label "VisibilitySensor detects when user can see a specific object or region as they navigate the world." .
+:center a owl:DatatypeProperty ;
+  rdfs:domain :VisibilitySensor ;
+  rdfs:range :SFVec3f .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# size field inheritedFrom=X3DEnvironmentalSensorNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:VolumeData a owl:Class ;
+  rdfs:subClassOf :X3DVolumeDataNode ;
+  rdfs:label "VolumeData displays a simple non-segmented voxel dataset with a single RenderStyle node." .
+# bboxCenter field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=0 0 0
+# bboxSize field inheritedFrom=X3DVolumeDataNode with accessType=initializeOnly, type=SFVec3f, default=-1 -1 -1, baseType=bboxSizeType
+# dimensions field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFVec3f, default=1 1 1
+# displayBBox field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=false
+:hasRenderStyle a owl:ObjectProperty ;
+  rdfs:domain :VolumeData ;
+  rdfs:range :X3DVolumeRenderStyleNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldRenderStyleHasParentVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasRenderStyle ;
+  rdfs:subPropertyOf :hasParentVolumeData .
+# visible field inheritedFrom=X3DVolumeDataNode with accessType=inputOutput, type=SFBool, default=true
+:hasVoxels a owl:ObjectProperty ;
+  rdfs:domain :VolumeData ;
+  rdfs:range :X3DTexture3DNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldVoxelsHasParentVolumeData a owl:ObjectProperty ;
+  owl:inverseOf :hasVoxels ;
+  rdfs:subPropertyOf :hasParentVolumeData .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:VolumeEmitter a owl:Class ;
+  rdfs:subClassOf :X3DParticleEmitterNode ;
+  rdfs:label "VolumeEmitter emits particles from a random position confined within the given closed geometry volume." .
+:hasCoord a owl:ObjectProperty ;
+  rdfs:domain :VolumeEmitter ;
+  rdfs:range :X3DCoordinateNode ;
+  rdfs:subPropertyOf :hasChild .
+:fieldCoordHasParentVolumeEmitter a owl:ObjectProperty ;
+  owl:inverseOf :hasCoord ;
+  rdfs:subPropertyOf :hasParentVolumeEmitter .
+:coordIndex a owl:DatatypeProperty ;
+  rdfs:domain :VolumeEmitter ;
+  rdfs:range :MFInt32 .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :VolumeEmitter ;
+  rdfs:range :SFVec3f .
+:internal a owl:DatatypeProperty ;
+  rdfs:domain :VolumeEmitter ;
+  rdfs:range :SFBool .
+# mass field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# speed field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0
+# surfaceArea field inheritedFrom=X3DParticleEmitterNode with accessType=initializeOnly, type=SFFloat, default=0
+# variation field inheritedFrom=X3DParticleEmitterNode with accessType=inputOutput, type=SFFloat, default=0.25
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:VolumePickSensor a owl:Class ;
+  rdfs:subClassOf :X3DPickSensorNode ;
+  rdfs:label "VolumePickSensor tests picking intersections using the pickingGeometry against the pickTarget geometry volume." .
+# enabled field inheritedFrom=X3DSensorNode with accessType=inputOutput, type=SFBool, default=true
+# intersectionType field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=BOUNDS, simpleType=intersectionTypeValues, baseType=xs:NMTOKEN
+# matchCriterion field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFString, default=MATCH_ANY, simpleType=pickSensorMatchCriterionChoices, baseType=xs:NMTOKEN
+# objectType field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFString, default="ALL", simpleType=pickableObjectTypeValues, baseType=MFString
+# pickingGeometry field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=SFNode, default=NULL
+# pickTarget field inheritedFrom=X3DPickSensorNode with accessType=inputOutput, type=MFNode
+# sortOrder field inheritedFrom=X3DPickSensorNode with accessType=initializeOnly, type=SFString, default=CLOSEST, simpleType=pickSensorSortOrderValues, baseType=xs:NMTOKEN
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:WindPhysicsModel a owl:Class ;
+  rdfs:subClassOf :X3DParticlePhysicsModelNode ;
+  rdfs:label "WindPhysicsModel applies a wind effect to the particles." .
+:direction a owl:DatatypeProperty ;
+  rdfs:domain :WindPhysicsModel ;
+  rdfs:range :SFVec3f .
+# enabled field inheritedFrom=X3DParticlePhysicsModelNode with accessType=inputOutput, type=SFBool, default=true
+:gustiness a owl:DatatypeProperty ;
+  rdfs:domain :WindPhysicsModel ;
+  rdfs:range :SFFloat .
+:speed a owl:DatatypeProperty ;
+  rdfs:domain :WindPhysicsModel ;
+  rdfs:range :SFFloat .
+:turbulence a owl:DatatypeProperty ;
+  rdfs:domain :WindPhysicsModel ;
+  rdfs:range :SFFloat .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+:WorldInfo a owl:Class ;
+  rdfs:subClassOf :X3DInfoNode ;
+  rdfs:label "WorldInfo contains a title and simple persistent metadata information about an X3D scene. This node is strictly for documentation purposes and has no effect on the visual appearance or behaviour of the world." .
+:info a owl:DatatypeProperty ;
+  rdfs:domain :WorldInfo ;
+  rdfs:range :MFString .
+:title a owl:DatatypeProperty ;
+  rdfs:domain :WorldInfo ;
+  rdfs:range :SFString .
+# DEF field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:ID
+# USE field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:IDREF
+# class field inheritedFrom=X3DNode with accessType=inputOutput, type=SFString, baseType=xs:NMTOKENS
+# IS field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+# metadata field inheritedFrom=X3DNode with accessType=inputOutput, type=SFNode, default=NULL
+
+###############################################
+            
+# Temporary knowledge base for testing
+
+:n1 rdf:type owl:NamedIndividual .
+:n2 rdf:type owl:NamedIndividual ;
+  :hasParent :n1 .
+:n3 rdf:type owl:NamedIndividual ;
+  :hasParent :n2 .
+
+###############################################


### PR DESCRIPTION
# Description

Added the X3D archetype schema with fixed on inappropriate domain literal values in owl:unionOf, and other syntax errors
Added a namespace file that included x3do, x3d, and dublin core
Added a README showcasing a schema level query and an instance query using one of the CAD examples

## Manual test plan:

Test 1:
Action: Create a database with the x3do archetype
Verify: database created with expected number of triples
Results:
```
──> stardog-admin db create -o database.archetypes="x3do" -n testx3db
Bulk loading data to new database testx3db.
Loaded 8,948 triples to testx3db from 2 file(s) in 00:00:01.869 @ 4.8K triples/sec.
Successfully created database 'testx3db'
```

Test 2:
Action: Create a database with teh x3do archetype and one other archetype
Verify: Database created with expected number of triples
Results:
```
└──> stardog-admin db create -o database.archetypes="x3do,cim" -n testcimx3db
Bulk loading data to new database testcimx3db.
Loaded 21,118 triples to testcimx3db from 4 file(s) in 00:00:01.745 @ 12.1K triples/sec.
Successfully created database 'testcimx3db'.
```

Test 3:
Action: Create a database with the x3do archetype
Verify: namespaces created
Results:
```
└──> stardog namespace list testx3db
+---------+-----------------------------------------------------+
| Prefix  |                      Namespace                      |
+---------+-----------------------------------------------------+
|         | http://api.stardog.com/                             |
| dc      | http://purl.org/dc/terms/                           |
| owl     | http://www.w3.org/2002/07/owl#                      |
| rdf     | http://www.w3.org/1999/02/22-rdf-syntax-ns#         |
| rdfs    | http://www.w3.org/2000/01/rdf-schema#               |
| stardog | tag:stardog:api:                                    |
| x3d     | http://www.web3d.org/specifications/x3d-4.0.xsd#    |
| x3do    | http://www.web3d.org/specifications/X3dOntology4.0# |
| xsd     | http://www.w3.org/2001/XMLSchema#                   |
+---------+-----------------------------------------------------+
```

Test 4:
Action: Create a database with the x3do archetype
Verify: Run the first example schema query in the README with reasoning
Results: Results as expected
Verify: Run the first example schema query in the README without reasoning
Results: Results as expected

Test 5:
Action: Create a database with the x3do archetype
Verify: Run the second example data query in the README with reasoning
Results: Results as expected
Verify: Run the second example data query in the README without reasoning
Results: Results as expected